### PR TITLE
Remove unnecessary MainActor.run usage in HomeViewModel

### DIFF
--- a/Cove/View Models/HomeViewModel.swift
+++ b/Cove/View Models/HomeViewModel.swift
@@ -9,6 +9,7 @@ import FirebaseFirestore
 import FirebaseStorage
 import FirebaseAuth
 
+@MainActor
 class HomeViewModel: ObservableObject {
     @Published var products = [any Product]()
     @Published var brands = [Brand]()
@@ -95,11 +96,7 @@ class HomeViewModel: ObservableObject {
                 }
             }
             
-            // Ensure the products array wont change while being sent to the main thread by making it constant
-            let sendableProducts = products
-            await MainActor.run(body: {
-                self.products = sendableProducts
-            })
+            self.products = products
         } catch {
             print(error)
             throw error
@@ -136,9 +133,7 @@ class HomeViewModel: ObservableObject {
                 return
             }
             
-            await MainActor.run(body: {
-                self.brands = brands
-            })
+            self.brands = brands
         } catch {
             print(error)
             throw error


### PR DESCRIPTION
## Summary
- Mark `HomeViewModel` with `@MainActor` so all methods inherently run on the main actor
- Remove both explicit `MainActor.run` wrappers in `fetchProducts` and `fetchBrands`
- Remove the now-unnecessary `sendableProducts` intermediate constant

Closes #61

## Test plan
- [x] Launch the app and verify the home screen loads products correctly
- [x] Verify brands load correctly
- [x] Verify favorites are reflected on products

🤖 Generated with [Claude Code](https://claude.com/claude-code)