### PR TITLE
Configure Claude GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: false # Disabled — re-enable by removing this line
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,18 +5,16 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  # issues:
+  #   types: [opened, assigned]
+  # pull_request_review:
+  #   types: [submitted]
 
 jobs:
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Disables `claude-code-review` workflow with `if: false` — runs on every PR open, not needed yet
- Removes `issues` and `pull_request_review` triggers from `claude.yml` to avoid unnecessary workflow spin-ups
- Cleans up dead conditions from the `if` block to match the remaining active triggers

## Re-enabling
- Code review: remove `if: false` from `claude-code-review.yml`
- Issue/PR review triggers: uncomment the `on:` triggers and add back the `if` conditions in `claude.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)