### PR TITLE
Add ProfileViewModel

### DIFF
--- a/Cove/View Models/ProfileViewModel.swift
+++ b/Cove/View Models/ProfileViewModel.swift
@@ -1,0 +1,47 @@
+//
+//  ProfileViewModel.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 3/15/26.
+//
+
+import FirebaseAuth
+
+@MainActor
+class ProfileViewModel: ObservableObject {
+    private var currentUser: User? { Auth.auth().currentUser }
+
+    var displayName: String {
+        if let name = currentUser?.displayName, !name.isEmpty {
+            return name
+        }
+        return emailPrefix
+    }
+
+    var username: String {
+        let slug = displayName.lowercased().replacingOccurrences(of: " ", with: "_")
+        return "@\(slug)"
+    }
+
+    var initials: String {
+        let words = displayName.split(separator: " ")
+        let letters = words.prefix(2).compactMap { $0.first }
+        return String(letters).uppercased()
+    }
+
+    var photoURL: URL? {
+        currentUser?.photoURL
+    }
+
+    var memberSinceText: String {
+        guard let date = currentUser?.metadata.creationDate else { return "" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return "Member since \(formatter.string(from: date))"
+    }
+
+    private var emailPrefix: String {
+        guard let email = currentUser?.email else { return "" }
+        return String(email.prefix(while: { $0 != "@" }))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ProfileViewModel` as an `@MainActor ObservableObject` deriving all profile data from Firebase Auth `currentUser`
- Nil-safe for email signup users where `displayName` is absent
- No Firestore or Storage calls — synchronous computed properties only

## Checklist (resolves #137)
- [x] `@MainActor class ProfileViewModel: ObservableObject`
- [x] `displayName` — uses Firebase displayName, falls back to email prefix
- [x] `username` — `@`-prefixed slug (lowercased, spaces → underscores)
- [x] `initials` — up to 2 characters from display name words (avatar fallback)
- [x] `photoURL` — mapped from `currentUser.photoURL`
- [x] `memberSinceText` — "Member since MMMM yyyy" from `metadata.creationDate`, empty string fallback
- [x] All properties nil-safe for email signup users
- [x] Follows `@MainActor ObservableObject` pattern from `HomeViewModel`

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)