### PR TITLE
Add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ ExportOptions.plist
 
 ### Claude hooks ###
 .claude/.dep-cleared-*
+
+### Claude worktrees ###
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/` to `.gitignore` so agent worktree directories are not tracked as untracked files in the main repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)