### PR TITLE
Fix inaccuracies in architecture docs and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Add ProfileViewModel with Firebase Auth user data
 - **Views** (`Views/`, `Components/`): SwiftUI only, no business logic
 - **ViewModels** (`View Models/`): `ObservableObject`, marked `@MainActor`, one per major view
 - **Models** (`Models/`): Data structures and global state (e.g. `AppState`, `Bag`)
-- **Enums** (`Enums/`): Shared enum types (`ProductTypes`, `AuthState`, `Path`)
+- **Enums** (`Enums/`): Shared enum types (`ProductTypes`); note that `AuthState`, `AuthMethod`, and `Path` are currently defined in `Models/AppState.swift`
 - **Styles** (`Styles/`): Custom `PrimitiveButtonStyle` implementations
 
 ### Naming

--- a/docs/APP_ARCHITECTURE.md
+++ b/docs/APP_ARCHITECTURE.md
@@ -12,15 +12,16 @@ Cove uses **MVVM (Model-View-ViewModel)** with SwiftUI. State is managed through
 
 ```
 Cove/
-├── Supporting Files/     # App entry point, Info.plist, GoogleService-Info.plist
+├── Supporting Files/     # App entry point (CoveApp.swift), Info.plist
 ├── Models/               # Data models and global state (AppState, Bag, Product types)
+│                         #   Also defines Path, AuthState, AuthMethod enums (in AppState.swift)
 ├── View Models/          # Business logic and Firestore access
 ├── Views/                # SwiftUI views organized by feature
 │   ├── Profile/          # ProfileHeaderView, StatsRowView, ProfileRowView
 │   └── ...               # HomeView, BagView, ProductDetailView, auth views
 ├── Components/           # Reusable UI components (ProductCardView, LikeButton, etc.)
 ├── Styles/               # Custom button styles and shadow modifiers
-├── Enums/                # ProductTypes, AuthMethod, AuthState, Path
+├── Enums/                # ProductTypes
 └── Resources/            # Assets, fonts (Gazpacho, Lato), Rive animations
 ```
 
@@ -58,6 +59,8 @@ enum Path: Hashable {
     case welcome
     case login
     case signup
+    case main
+    case home
     case product(id: String)   // Product detail navigation within tabs
 }
 ```


### PR DESCRIPTION
## Summary
- Corrected `Enums/` description in both `CLAUDE.md` and `docs/APP_ARCHITECTURE.md` — only `ProductTypes` lives there; `AuthState`, `AuthMethod`, and `Path` are actually defined in `Models/AppState.swift`
- Removed `GoogleService-Info.plist` from the `Supporting Files/` tree entry (it is not committed to the repo)
- Added the missing `case main` and `case home` cases to the documented `Path` enum

## What a reviewer should know
These were documentation-only fixes — no source code changed. The inaccuracies were caught by a documentation-maintainer audit comparing the docs against the actual codebase.