### PR TITLE
Fix favorites processing loop to skip corrupted entries

### DIFF
--- a/Cove/View Models/HomeViewModel.swift
+++ b/Cove/View Models/HomeViewModel.swift
@@ -34,18 +34,17 @@ class HomeViewModel: ObservableObject {
         return nil
     }
 
-    private func applyFavorites(to products: inout [any Product], snapshot: QuerySnapshot) throws {
+    private func applyFavorites(to products: inout [any Product], snapshot: QuerySnapshot) {
         for document in snapshot.documents {
             do {
                 let favoriteProduct = try document.data(as: FavoriteProduct.self)
                 guard let index = products.firstIndex(where: { $0.id == favoriteProduct.productId }) else {
-                    print("Failed to get local index of favorite product")
-                    return
+                    print("Failed to get local index of favorite product: \(favoriteProduct.productId)")
+                    continue
                 }
                 products[index].isFavorite = true
             } catch {
-                print(error)
-                throw error
+                print("Failed to decode favorite: \(error)")
             }
         }
     }
@@ -81,7 +80,7 @@ class HomeViewModel: ObservableObject {
                 .whereField("productId", in: fetchedProductIds)
                 .getDocuments()
 
-            try applyFavorites(to: &products, snapshot: snapshot)
+            applyFavorites(to: &products, snapshot: snapshot)
 
             self.products = products
         } catch {


### PR DESCRIPTION
## Summary
- Replace `throw error` with a log-and-continue in the favorites decoding loop so one corrupted document doesn't abort the entire fetch
- Replace `return` with `continue` in the guard so missing local index skips that favorite instead of exiting early
- Remove `throws` from `applyFavorites` since errors are now handled internally

## Test plan
- [ ] Verify products are still marked as favorites correctly in the happy path
- [ ] Simulate a corrupted favorites document and confirm the rest still load

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)