### PR TITLE
Implement caching/refresh strategy for products

### DIFF
--- a/Cove/Components/LikeButton.swift
+++ b/Cove/Components/LikeButton.swift
@@ -8,15 +8,20 @@
 import SwiftUI
 
 struct LikeButton: View {
-    @State var enabled: Bool
+    let productId: String
     var size: CGFloat = 26
     var outlined: Bool = false
-    var onToggle: (() -> Void)? = nil
+
+    @EnvironmentObject private var favoritesStore: FavoritesStore
     @State private var pressed = false
     @State private var scale = 1.0
 
     private var iconSize: CGFloat {
         size * (14.0 / 26.0)
+    }
+
+    private var enabled: Bool {
+        favoritesStore.isFavorite(productId)
     }
 
     func haptic() {
@@ -47,30 +52,8 @@ struct LikeButton: View {
                 withAnimation(.easeOut(duration: 0.3)) {
                     scale = 1.0
                 }
-                enabled.toggle()
-                onToggle?()
+                Task { await favoritesStore.toggle(productId) }
             }
         }, perform: {})
     }
 }
-
-// struct StatefulPreviewWrapper<Value, Content: View>: View {
-//    @State var value: Value
-//    var content: (Binding<Value>) -> Content
-//
-//    var body: some View {
-//        content($value)
-//    }
-//
-//    init(_ value: Value, content: @escaping (Binding<Value>) -> Content) {
-//        self._value = State(wrappedValue: value)
-//        self.content = content
-//    }
-// }
-//
-// struct LikeButton_Previews: PreviewProvider {
-//    static var previews: some View {
-//        StatefulPreviewWrapper(false) { LikeButton(enabled: $0) }
-//        .previewLayout(.sizeThatFits)
-//    }
-// }

--- a/Cove/Components/LikeButton.swift
+++ b/Cove/Components/LikeButton.swift
@@ -11,6 +11,7 @@ struct LikeButton: View {
     @State var enabled: Bool
     var size: CGFloat = 26
     var outlined: Bool = false
+    var onToggle: (() -> Void)? = nil
     @State private var pressed = false
     @State private var scale = 1.0
 
@@ -47,6 +48,7 @@ struct LikeButton: View {
                     scale = 1.0
                 }
                 enabled.toggle()
+                onToggle?()
             }
         }, perform: {})
     }

--- a/Cove/Components/ProductCardView.swift
+++ b/Cove/Components/ProductCardView.swift
@@ -22,16 +22,11 @@ struct ProductCardView: View {
     var subtitleStr: String = "Subtitle"
     var price: Float = 9
 
-    @State var favorited: Bool
     @State private var uiImage: UIImage?
     @State private var averageColor: Color = .white // Default background color
 
     init(product: any Product) {
         self.product = product
-
-//        print("ProductCardView init: \(String(describing: product.id)) favorite: \(String(describing: product.isFavorite))")
-
-        _favorited = State(initialValue: product.isFavorite ?? false)
 
         if let coffeeProduct = product as? CoffeeProduct {
             // product is a CoffeeProduct
@@ -58,17 +53,12 @@ struct ProductCardView: View {
                     cardContent
                 }
                 .buttonStyle(PlainButtonStyle())
+
+                LikeButton(productId: productId)
+                    .padding(10)
             } else {
-                // If no product ID, show card without navigation
                 cardContent
             }
-
-            LikeButton(enabled: favorited)
-                // .shadow(color: .dropShadow, radius: 20)
-                .padding(10)
-                .onChange(of: product.isFavorite) { _, newValue in
-                    favorited = newValue ?? false
-                }
         }
     }
 

--- a/Cove/Components/ProductCardView.swift
+++ b/Cove/Components/ProductCardView.swift
@@ -66,6 +66,9 @@ struct ProductCardView: View {
             LikeButton(enabled: favorited)
                 // .shadow(color: .dropShadow, radius: 20)
                 .padding(10)
+                .onChange(of: product.isFavorite) { _, newValue in
+                    favorited = newValue ?? false
+                }
         }
     }
 

--- a/Cove/Models/FavoritesStore.swift
+++ b/Cove/Models/FavoritesStore.swift
@@ -1,0 +1,82 @@
+//
+//  FavoritesStore.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 4/18/26.
+//
+
+import FirebaseAuth
+import FirebaseFirestore
+
+@MainActor
+class FavoritesStore: ObservableObject {
+    @Published private(set) var favoriteIds: Set<String> = []
+
+    private var authListener: AuthStateDidChangeListenerHandle?
+
+    init() {
+        authListener = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            Task { @MainActor in
+                if user != nil {
+                    await self?.loadFavorites()
+                } else {
+                    self?.favoriteIds = []
+                }
+            }
+        }
+    }
+
+    deinit {
+        if let authListener {
+            Auth.auth().removeStateDidChangeListener(authListener)
+        }
+    }
+
+    func isFavorite(_ productId: String) -> Bool {
+        favoriteIds.contains(productId)
+    }
+
+    func loadFavorites() async {
+        guard let user = Auth.auth().currentUser else { return }
+        let firestore = Firestore.firestore()
+        do {
+            let snapshot = try await firestore.collection("users").document(user.uid).collection("favorites").getDocuments()
+            let ids = snapshot.documents.compactMap { try? $0.data(as: FavoriteProduct.self).productId }
+            favoriteIds = Set(ids)
+        } catch {
+            print("Error loading favorites: \(error)")
+        }
+    }
+
+    func toggle(_ productId: String) async {
+        guard let user = Auth.auth().currentUser else { return }
+        let wasFavorite = favoriteIds.contains(productId)
+
+        if wasFavorite {
+            favoriteIds.remove(productId)
+        } else {
+            favoriteIds.insert(productId)
+        }
+
+        let favoritesRef = Firestore.firestore()
+            .collection("users").document(user.uid).collection("favorites")
+
+        do {
+            if wasFavorite {
+                let snapshot = try await favoritesRef.whereField("productId", isEqualTo: productId).getDocuments()
+                for document in snapshot.documents {
+                    try await document.reference.delete()
+                }
+            } else {
+                try await favoritesRef.addDocument(from: FavoriteProduct(productId: productId))
+            }
+        } catch {
+            print("Error toggling favorite: \(error)")
+            if wasFavorite {
+                favoriteIds.insert(productId)
+            } else {
+                favoriteIds.remove(productId)
+            }
+        }
+    }
+}

--- a/Cove/Supporting Files/CoveApp.swift
+++ b/Cove/Supporting Files/CoveApp.swift
@@ -44,6 +44,7 @@ struct CoveApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject var appState = AppState()
     @StateObject var bag = Bag()
+    @StateObject var favoritesStore = FavoritesStore()
     @StateObject private var networkMonitor = NetworkMonitor()
 
     @State var text: String = ""
@@ -88,6 +89,7 @@ struct CoveApp: App {
                 }
             }
             .environmentObject(appState)
+            .environmentObject(favoritesStore)
             .onOpenURL { url in
                 GIDSignIn.sharedInstance.handle(url)
             }

--- a/Cove/View Models/HomeViewModel.swift
+++ b/Cove/View Models/HomeViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by Daniel Cajiao on 12/6/22.
 //
 
-import FirebaseAuth
 import FirebaseFirestore
 import FirebaseStorage
 
@@ -13,7 +12,6 @@ import FirebaseStorage
 class HomeViewModel: ObservableObject {
     @Published var products = [any Product]()
     @Published var brands = [Brand]()
-    var fetchedProductIds = [String]()
 
     let categories = ["Music", "Coffee", "Home", "Bevs", "Apparel"]
     let origins = ["Colombia", "Guatemala", "Ethiopia", "Costa Rica", "Kenya"]
@@ -37,69 +35,22 @@ class HomeViewModel: ObservableObject {
         return nil
     }
 
-    private func applyFavorites(to products: inout [any Product], snapshot: QuerySnapshot) {
-        for document in snapshot.documents {
-            do {
-                let favoriteProduct = try document.data(as: FavoriteProduct.self)
-                guard let index = products.firstIndex(where: { $0.id == favoriteProduct.productId }) else {
-                    print("Failed to get local index of favorite product: \(favoriteProduct.productId)")
-                    continue
-                }
-                products[index].isFavorite = true
-            } catch {
-                print("Failed to decode favorite: \(error)")
-            }
-        }
-    }
-
-    func refreshFavorites() async throws {
-        guard !fetchedProductIds.isEmpty else { return }
-        guard let user = Auth.auth().currentUser else { return }
-
-        let firestore = Firestore.firestore()
-        let snapshot = try await firestore.collection("users").document(user.uid).collection("favorites")
-            .whereField("productId", in: fetchedProductIds)
-            .getDocuments()
-
-        for i in products.indices {
-            products[i].isFavorite = false
-        }
-        applyFavorites(to: &products, snapshot: snapshot)
-    }
-
     /// Fetches products from Firebase and populates the products array used in the HomeView
     func fetchProducts(forceRefresh: Bool = false) async throws {
         let cacheExpired = lastFetchTime.map { Date().timeIntervalSince($0) > cacheTimeout } ?? true
         guard products.isEmpty || forceRefresh || cacheExpired else { return }
 
         print("Fetching products...")
-        fetchedProductIds = []
         let firestore = Firestore.firestore()
 
         do {
-            var snapshot = try await firestore.collection("products").getDocuments()
-
-            var products: [any Product] = snapshot.documents.compactMap { document in
-                guard let product = decodeProduct(from: document) else { return nil }
-                fetchedProductIds.append(document.documentID)
-                return product
-            }
+            let snapshot = try await firestore.collection("products").getDocuments()
+            let products: [any Product] = snapshot.documents.compactMap { decodeProduct(from: $0) }
 
             if products.isEmpty {
                 print("No products returned from request")
                 return
             }
-
-            guard let user = Auth.auth().currentUser else {
-                print("Failed to get signed in user to fetch favorites")
-                return
-            }
-
-            snapshot = try await firestore.collection("users").document(user.uid).collection("favorites")
-                .whereField("productId", in: fetchedProductIds)
-                .getDocuments()
-
-            applyFavorites(to: &products, snapshot: snapshot)
 
             self.products = products
             lastFetchTime = Date()
@@ -110,20 +61,14 @@ class HomeViewModel: ObservableObject {
     }
 
     func fetchBrands() async throws {
-        // Check if products have already been fetched
-        if !brands.isEmpty {
-            return
-        }
+        if !brands.isEmpty { return }
 
-        // Get a reference to Firestore
         print("Fetching brands...")
         let firestore = Firestore.firestore()
 
         do {
-            // Fetch 'brand' documents from the 'brands' collection
             let snapshot = try await firestore.collection("brands").getDocuments()
 
-            // Map fetched documents to the `brands` array
             let brands: [Brand] = snapshot.documents.compactMap { document in
                 do {
                     return try document.data(as: Brand.self)
@@ -133,7 +78,6 @@ class HomeViewModel: ObservableObject {
                 }
             }
 
-            // Check if no brands were fetched from last request
             if brands.isEmpty {
                 print("No brands returned from request")
                 return

--- a/Cove/View Models/HomeViewModel.swift
+++ b/Cove/View Models/HomeViewModel.swift
@@ -18,6 +18,9 @@ class HomeViewModel: ObservableObject {
     let categories = ["Music", "Coffee", "Home", "Bevs", "Apparel"]
     let origins = ["Colombia", "Guatemala", "Ethiopia", "Costa Rica", "Kenya"]
 
+    private var lastFetchTime: Date?
+    private let cacheTimeout: TimeInterval = 300
+
     private func decodeProduct(from document: QueryDocumentSnapshot) -> (any Product)? {
         let categoryId = document["categoryId"] as? String
         do {
@@ -49,12 +52,28 @@ class HomeViewModel: ObservableObject {
         }
     }
 
+    func refreshFavorites() async throws {
+        guard !fetchedProductIds.isEmpty else { return }
+        guard let user = Auth.auth().currentUser else { return }
+
+        let firestore = Firestore.firestore()
+        let snapshot = try await firestore.collection("users").document(user.uid).collection("favorites")
+            .whereField("productId", in: fetchedProductIds)
+            .getDocuments()
+
+        for i in products.indices {
+            products[i].isFavorite = false
+        }
+        applyFavorites(to: &products, snapshot: snapshot)
+    }
+
     /// Fetches products from Firebase and populates the products array used in the HomeView
-    func fetchProducts() async throws {
-        if !products.isEmpty { return }
+    func fetchProducts(forceRefresh: Bool = false) async throws {
+        let cacheExpired = lastFetchTime.map { Date().timeIntervalSince($0) > cacheTimeout } ?? true
+        guard products.isEmpty || forceRefresh || cacheExpired else { return }
 
         print("Fetching products...")
-        fetchedProductIds = [String]()
+        fetchedProductIds = []
         let firestore = Firestore.firestore()
 
         do {
@@ -83,6 +102,7 @@ class HomeViewModel: ObservableObject {
             applyFavorites(to: &products, snapshot: snapshot)
 
             self.products = products
+            lastFetchTime = Date()
         } catch {
             print(error)
             throw error

--- a/Cove/View Models/ProductDetailViewModel.swift
+++ b/Cove/View Models/ProductDetailViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by Daniel Cajiao on 4/9/23.
 //
 
-import FirebaseAuth
 import FirebaseFirestore
 
 class ProductDetailViewModel: ObservableObject {
@@ -13,7 +12,6 @@ class ProductDetailViewModel: ObservableObject {
     @Published var productDetails: ProductDetails?
     @Published var detailSelection: DetailSelection
     @Published var similarProducts: [any Product]
-    var fetchedProductIds = [String]()
 
     enum DetailSelection {
         case description
@@ -71,47 +69,8 @@ class ProductDetailViewModel: ObservableObject {
             } else {
                 print("Unknown product category: \(categoryId)")
             }
-
-            await fetchFavoriteStatus(for: id)
         } catch {
             print("Error fetching product: \(error)")
-        }
-    }
-
-    private func fetchFavoriteStatus(for productId: String) async {
-        guard let user = Auth.auth().currentUser else { return }
-        let firestore = Firestore.firestore()
-        do {
-            let snapshot = try await firestore.collection("users").document(user.uid).collection("favorites")
-                .whereField("productId", isEqualTo: productId)
-                .getDocuments()
-            let isFavorite = !snapshot.documents.isEmpty
-            await MainActor.run { self.product?.isFavorite = isFavorite }
-        } catch {
-            print("Error fetching favorite status: \(error)")
-        }
-    }
-
-    func toggleFavorite() async {
-        guard let productId = product?.id else { return }
-        guard let user = Auth.auth().currentUser else { return }
-
-        let isCurrentlyFavorited = product?.isFavorite == true
-        let firestore = Firestore.firestore()
-        let favoritesRef = firestore.collection("users").document(user.uid).collection("favorites")
-
-        do {
-            if isCurrentlyFavorited {
-                let snapshot = try await favoritesRef.whereField("productId", isEqualTo: productId).getDocuments()
-                for document in snapshot.documents {
-                    try await document.reference.delete()
-                }
-            } else {
-                try await favoritesRef.addDocument(from: FavoriteProduct(productId: productId))
-            }
-            await MainActor.run { self.product?.isFavorite = !isCurrentlyFavorited }
-        } catch {
-            print("Error toggling favorite: \(error)")
         }
     }
 
@@ -170,61 +129,27 @@ class ProductDetailViewModel: ObservableObject {
         return nil
     }
 
-    private func applyFavorites(to products: inout [any Product], snapshot: QuerySnapshot) throws {
-        for document in snapshot.documents {
-            do {
-                let favoriteProduct = try document.data(as: FavoriteProduct.self)
-                guard let index = products.firstIndex(where: { $0.id == favoriteProduct.productId }) else {
-                    print("Failed to get local index of favorite product")
-                    return
-                }
-                products[index].isFavorite = true
-            } catch {
-                print(error)
-                throw error
-            }
-        }
-    }
-
-    /// Fetches products from Firebase and populates the products array used in the HomeView
     func fetchSimilarProducts() async throws {
         if !similarProducts.isEmpty { return }
         guard let product else { return }
 
         print("Fetching similar products...")
-        fetchedProductIds = [String]()
         let firestore = Firestore.firestore()
 
         do {
-            var snapshot = try await firestore.collection("products")
+            let snapshot = try await firestore.collection("products")
                 .whereField("categoryId", isEqualTo: product.categoryId)
                 .limit(to: 5)
                 .getDocuments()
 
-            var products: [any Product] = snapshot.documents.compactMap { document in
-                guard let decoded = decodeProduct(from: document) else { return nil }
-                fetchedProductIds.append(document.documentID)
-                return decoded
-            }
+            let products: [any Product] = snapshot.documents.compactMap { decodeProduct(from: $0) }
 
             if products.isEmpty {
                 print("No products returned from request")
                 return
             }
 
-            guard let user = Auth.auth().currentUser else {
-                print("Failed to get signed in user to fetch favorites")
-                return
-            }
-
-            snapshot = try await firestore.collection("users").document(user.uid).collection("favorites")
-                .whereField("productId", in: fetchedProductIds)
-                .getDocuments()
-
-            try applyFavorites(to: &products, snapshot: snapshot)
-
-            let sendableProducts = products
-            await MainActor.run(body: { self.similarProducts = sendableProducts })
+            await MainActor.run { self.similarProducts = products }
         } catch {
             print(error)
             throw error

--- a/Cove/View Models/ProductDetailViewModel.swift
+++ b/Cove/View Models/ProductDetailViewModel.swift
@@ -47,42 +47,71 @@ class ProductDetailViewModel: ObservableObject {
         let firestore = Firestore.firestore()
 
         do {
-            // Fetch the product document from Firestore
             let snapshot = try await firestore.collection("products").document(id).getDocument()
 
-            // Check if document exists
             guard snapshot.exists else {
                 print("Product with id \(id) does not exist")
                 return
             }
 
-            // Get the categoryId to determine the product type
             guard let categoryId = snapshot["categoryId"] as? String else {
                 print("Product document missing categoryId field")
                 return
             }
 
-            // Decode based on product type
             if categoryId == ProductTypes.coffee.rawValue {
                 let coffeeProduct = try snapshot.data(as: CoffeeProduct.self)
-                await MainActor.run {
-                    self.product = coffeeProduct
-                }
+                await MainActor.run { self.product = coffeeProduct }
             } else if categoryId == ProductTypes.music.rawValue {
                 let musicProduct = try snapshot.data(as: MusicProduct.self)
-                await MainActor.run {
-                    self.product = musicProduct
-                }
+                await MainActor.run { self.product = musicProduct }
             } else if categoryId == ProductTypes.apparel.rawValue {
                 let apparelProduct = try snapshot.data(as: ApparelProduct.self)
-                await MainActor.run {
-                    self.product = apparelProduct
-                }
+                await MainActor.run { self.product = apparelProduct }
             } else {
                 print("Unknown product category: \(categoryId)")
             }
+
+            await fetchFavoriteStatus(for: id)
         } catch {
             print("Error fetching product: \(error)")
+        }
+    }
+
+    private func fetchFavoriteStatus(for productId: String) async {
+        guard let user = Auth.auth().currentUser else { return }
+        let firestore = Firestore.firestore()
+        do {
+            let snapshot = try await firestore.collection("users").document(user.uid).collection("favorites")
+                .whereField("productId", isEqualTo: productId)
+                .getDocuments()
+            let isFavorite = !snapshot.documents.isEmpty
+            await MainActor.run { self.product?.isFavorite = isFavorite }
+        } catch {
+            print("Error fetching favorite status: \(error)")
+        }
+    }
+
+    func toggleFavorite() async {
+        guard let productId = product?.id else { return }
+        guard let user = Auth.auth().currentUser else { return }
+
+        let isCurrentlyFavorited = product?.isFavorite == true
+        let firestore = Firestore.firestore()
+        let favoritesRef = firestore.collection("users").document(user.uid).collection("favorites")
+
+        do {
+            if isCurrentlyFavorited {
+                let snapshot = try await favoritesRef.whereField("productId", isEqualTo: productId).getDocuments()
+                for document in snapshot.documents {
+                    try await document.reference.delete()
+                }
+            } else {
+                try await favoritesRef.addDocument(from: FavoriteProduct(productId: productId))
+            }
+            await MainActor.run { self.product?.isFavorite = !isCurrentlyFavorited }
+        } catch {
+            print("Error toggling favorite: \(error)")
         }
     }
 

--- a/Cove/Views/HomeView.swift
+++ b/Cove/Views/HomeView.swift
@@ -139,11 +139,16 @@ struct HomeView: View {
         }
 //        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.Colors.Backgrounds.primary.ignoresSafeArea(.all))
+        .refreshable {
+            try? await viewModel.fetchProducts(forceRefresh: true)
+            try? await viewModel.fetchBrands()
+        }
         .onAppear {
             print("homeView appeared")
             Task {
                 try await viewModel.fetchProducts()
                 try await viewModel.fetchBrands()
+                try await viewModel.refreshFavorites()
             }
         }
     }

--- a/Cove/Views/HomeView.swift
+++ b/Cove/Views/HomeView.swift
@@ -148,7 +148,6 @@ struct HomeView: View {
             Task {
                 try await viewModel.fetchProducts()
                 try await viewModel.fetchBrands()
-                try await viewModel.refreshFavorites()
             }
         }
     }

--- a/Cove/Views/ProductDetailView.swift
+++ b/Cove/Views/ProductDetailView.swift
@@ -244,6 +244,7 @@ private struct ProductDetailContent: View {
                     LikeButton(enabled: product.isFavorite ?? false, size: 40, outlined: true, onToggle: {
                         Task { await viewModel.toggleFavorite() }
                     })
+                    .id(product.isFavorite)
 
                     Button {
                         if !bag.bagProducts.contains(where: { bagProduct in

--- a/Cove/Views/ProductDetailView.swift
+++ b/Cove/Views/ProductDetailView.swift
@@ -241,7 +241,9 @@ private struct ProductDetailContent: View {
                     //         LikeButton(enabled: product.isFavorite ?? false)
                     //     }
 
-                    LikeButton(enabled: product.isFavorite ?? false, size: 40, outlined: true)
+                    LikeButton(enabled: product.isFavorite ?? false, size: 40, outlined: true, onToggle: {
+                        Task { await viewModel.toggleFavorite() }
+                    })
 
                     Button {
                         if !bag.bagProducts.contains(where: { bagProduct in

--- a/Cove/Views/ProductDetailView.swift
+++ b/Cove/Views/ProductDetailView.swift
@@ -241,10 +241,9 @@ private struct ProductDetailContent: View {
                     //         LikeButton(enabled: product.isFavorite ?? false)
                     //     }
 
-                    LikeButton(enabled: product.isFavorite ?? false, size: 40, outlined: true, onToggle: {
-                        Task { await viewModel.toggleFavorite() }
-                    })
-                    .id(product.isFavorite)
+                    if let productId = product.id {
+                        LikeButton(productId: productId, size: 40, outlined: true)
+                    }
 
                     Button {
                         if !bag.bagProducts.contains(where: { bagProduct in


### PR DESCRIPTION
## Summary
- Add `FavoritesStore` as a centralized `@EnvironmentObject` — single source of truth for favorite state across all views
- `FavoritesStore` holds a `Set<String>` of favorite product IDs, auto-loads on sign-in via Firebase Auth listener, clears on sign-out, and handles optimistic toggling with Firestore write-back
- `LikeButton` now takes `productId` and reads/writes the store directly — no more scattered local `@State`, no more `onToggle` callbacks, no more `.id()` patches
- `HomeViewModel.fetchProducts()` uses a 5-minute time-based cache with `forceRefresh` — no longer tracks favorite state
- Pull-to-refresh on `HomeView` via `.refreshable`
- Removed `refreshFavorites()`, `applyFavorites()`, `toggleFavorite()`, `fetchFavoriteStatus()` from both view models

## Test plan
- [x] Sign in → favorites load automatically, hearts reflect correct state on all product cards
- [x] Long-press heart on HomeView card → toggles instantly on that card AND the same product's detail view
- [x] Long-press heart in ProductDetailView → toggles instantly, reflected on HomeView card when navigating back
- [x] Sign out and back in → favorites reload correctly
- [x] Pull-to-refresh on HomeView → re-fetches products, favorite state stays correct

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)