### PR TITLE
Add FavoritesViewModel with Firestore favorites fetch

### DIFF
--- a/Cove/View Models/FavoritesViewModel.swift
+++ b/Cove/View Models/FavoritesViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by Daniel Cajiao on 4/18/26.
 //
 
-import FirebaseAuth
 import FirebaseFirestore
 
 @MainActor

--- a/Cove/View Models/FavoritesViewModel.swift
+++ b/Cove/View Models/FavoritesViewModel.swift
@@ -57,8 +57,8 @@ class FavoritesViewModel: ObservableObject {
             }
 
             guard !productIds.isEmpty else {
-                self.favorites = []
-                self.favoriteCount = 0
+                favorites = []
+                favoriteCount = 0
                 return
             }
 
@@ -66,7 +66,7 @@ class FavoritesViewModel: ObservableObject {
 
             for batchStart in stride(from: 0, to: productIds.count, by: 30) {
                 let batchEnd = min(batchStart + 30, productIds.count)
-                let batch = Array(productIds[batchStart..<batchEnd])
+                let batch = Array(productIds[batchStart ..< batchEnd])
 
                 let productsSnapshot = try await firestore
                     .collection("products")
@@ -77,8 +77,8 @@ class FavoritesViewModel: ObservableObject {
                 fetchedProducts.append(contentsOf: batchProducts)
             }
 
-            self.favorites = fetchedProducts
-            self.favoriteCount = fetchedProducts.count
+            favorites = fetchedProducts
+            favoriteCount = fetchedProducts.count
         } catch {
             print(error)
             throw error

--- a/Cove/View Models/FavoritesViewModel.swift
+++ b/Cove/View Models/FavoritesViewModel.swift
@@ -1,0 +1,88 @@
+//
+//  FavoritesViewModel.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 4/18/26.
+//
+
+import FirebaseAuth
+import FirebaseFirestore
+
+@MainActor
+class FavoritesViewModel: ObservableObject {
+    @Published var favorites: [any Product] = []
+    @Published var isLoading: Bool = false
+    @Published var favoriteCount: Int = 0
+
+    private func decodeProduct(from document: DocumentSnapshot) -> (any Product)? {
+        let categoryId = document["categoryId"] as? String
+        do {
+            if categoryId == ProductTypes.coffee.rawValue {
+                return try document.data(as: CoffeeProduct.self)
+            } else if categoryId == ProductTypes.music.rawValue {
+                return try document.data(as: MusicProduct.self)
+            } else if categoryId == ProductTypes.apparel.rawValue {
+                return try document.data(as: ApparelProduct.self)
+            }
+        } catch {
+            print(error)
+        }
+        return nil
+    }
+
+    func fetchFavorites() async throws {
+        guard let uid = Auth.auth().currentUser?.uid else {
+            print("No user signed in")
+            return
+        }
+
+        isLoading = true
+        defer { isLoading = false }
+
+        let firestore = Firestore.firestore()
+
+        do {
+            let favoritesSnapshot = try await firestore
+                .collection("users")
+                .document(uid)
+                .collection("favorites")
+                .getDocuments()
+
+            let productIds: [String] = favoritesSnapshot.documents.compactMap { document in
+                do {
+                    return try document.data(as: FavoriteProduct.self).productId
+                } catch {
+                    print(error)
+                    return nil
+                }
+            }
+
+            guard !productIds.isEmpty else {
+                self.favorites = []
+                self.favoriteCount = 0
+                return
+            }
+
+            var fetchedProducts: [any Product] = []
+
+            for batchStart in stride(from: 0, to: productIds.count, by: 30) {
+                let batchEnd = min(batchStart + 30, productIds.count)
+                let batch = Array(productIds[batchStart..<batchEnd])
+
+                let productsSnapshot = try await firestore
+                    .collection("products")
+                    .whereField(FieldPath.documentID(), in: batch)
+                    .getDocuments()
+
+                let batchProducts: [any Product] = productsSnapshot.documents.compactMap { decodeProduct(from: $0) }
+                fetchedProducts.append(contentsOf: batchProducts)
+            }
+
+            self.favorites = fetchedProducts
+            self.favoriteCount = fetchedProducts.count
+        } catch {
+            print(error)
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `FavoritesViewModel`, a `@MainActor ObservableObject` that fetches the signed-in user's favorited products from Firestore
- Reads `users/{uid}/favorites` documents to collect `productId` values, then fetches matching `products` documents in batches of ≤ 30 using `stride(from:to:by:)`
- Decodes each product document into the correct type (`CoffeeProduct`, `MusicProduct`, or `ApparelProduct`) based on `categoryId`, matching the logic in `HomeViewModel`
- Individual decode failures are logged and skipped without aborting the fetch; guards against nil `currentUser`

## Test plan
- [ ] Verify `fetchFavorites()` populates `favorites` correctly when the user has favorited products
- [ ] Verify `isLoading` toggles to `true` during the fetch and back to `false` after
- [ ] Verify `favoriteCount` stays in sync with `favorites.count`
- [ ] Verify that a user with no favorites results in an empty `favorites` array without error
- [ ] Verify a signed-out user prints the "No user signed in" message and returns early
- [ ] Verify that a single malformed product document is skipped while the rest are decoded successfully

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)