### PR TITLE
Improve agent workflow: SwiftFormat/SwiftLint step and epic integration branches

### DIFF
--- a/.claude/agents/github-project-planner.md
+++ b/.claude/agents/github-project-planner.md
@@ -63,8 +63,26 @@ Present the final plan — including which UI sub-issues have Figma links — an
 
 ### 5. Execute
 1. Create the epic with `mcp__plugin_github_github__issue_write` → capture its `number` and `id`
-2. Create each sub-issue → capture each `id`
-3. Link each sub-issue to the epic with `mcp__plugin_github_github__sub_issue_write` — one at a time, sequentially
+2. Create the integration branch from `main` using the Bash tool:
+   ```bash
+   gh api repos/danicajiao/cove-ios/git/refs \
+     -X POST \
+     -f ref="refs/heads/feature/<epic-number>-<short-description>" \
+     -f sha="$(gh api repos/danicajiao/cove-ios/git/ref/heads/main --jq '.object.sha')"
+   ```
+   The branch name follows the standard convention: `feature/<epic-number>-<short-description>`.
+3. Create each sub-issue → capture each `id`. Include the integration branch name in each sub-issue's **Technical Notes** section so the implementing agent knows where to target its PR.
+4. Link each sub-issue to the epic with `mcp__plugin_github_github__sub_issue_write` — one at a time, sequentially
+5. Open a draft PR from the integration branch to `main` so it's visible and ready for when sub-issues are merged:
+   ```bash
+   gh pr create \
+     --repo danicajiao/cove-ios \
+     --title "<Epic Title>" \
+     --body "Integration branch for epic #<epic-number>. Merge after all sub-issues are merged and tested.\n\nCloses #<epic-number>" \
+     --base main \
+     --head feature/<epic-number>-<short-description> \
+     --draft
+   ```
 
 ---
 
@@ -175,7 +193,9 @@ The issues you create are the top of a multi-agent pipeline. Once an issue is cr
 
 - `ui/ux + figma` sub-issues → picked up by the `figma-ui-implementer` agent, which reads the issue body as its spec, implements the view in a worktree, and creates a PR that closes the issue
 - The branch the agent works on is named after the issue: `feature/<issue-id>-<short-description>`
+- Sub-issue PRs target the **integration branch** (`feature/<epic-id>-<description>`), not `main` — include the integration branch name in each sub-issue's Technical Notes so agents know where to target
 - The PR description contains `Closes #<issue-id>`, which auto-closes the issue on merge
+- Once all sub-issues are merged into the integration branch, the draft PR from the integration branch to `main` is reviewed, tested, and merged to close the epic
 
 **What this means for issue quality:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,8 @@ Font.custom("Lato-Regular", size: 14)      // body
 - Indentation: 4 spaces
 - Max line width: 150 characters (SwiftFormat), 200 warning / 250 error (SwiftLint)
 - No semicolons
-- Run SwiftFormat before committing (config in `.swiftformat`)
+- Run `swiftformat .` before committing (config in `.swiftformat`)
+- Run `swiftlint` before committing and resolve any errors
 
 ---
 
@@ -135,22 +136,34 @@ Claude agents run in isolated git worktrees — each agent gets its own director
 ```
 github-project-planner
   └── creates epic + sub-issues on GitHub
-        └── sub-issue (e.g. ui/ux + figma) is picked up by an agent
-              └── harness spins up a worktree: branch claude/<name>, isolated directory
-                    └── agent renames branch: feature/<issue-id>-<desc>
-                          └── agent implements, commits, pushes
-                                └── PR created with "Closes #<issue-id>"
-                                      └── PR merged → issue auto-closed
+        └── creates integration branch: feature/<epic-id>-<description>
+              └── sub-issue is picked up by an agent
+                    └── harness spins up a worktree: branch claude/<name>, isolated directory
+                          └── agent renames branch: feature/<issue-id>-<desc>
+                                └── agent implements, runs swiftformat + swiftlint, commits, pushes
+                                      └── PR created targeting integration branch with "Closes #<issue-id>"
+                                            └── PRs merged into integration branch → tested in main repo
+                                                  └── integration branch PR merged to main → epic closed
 ```
 
 Multiple sub-issues can be in-flight simultaneously, each in its own worktree, each on its own branch. They never touch each other's files.
+
+### Integration branches
+
+Every epic gets an integration branch created by `github-project-planner` at planning time. Sub-issue PRs target this branch instead of `main`, so all changes can be built and tested together before touching `main`.
+
+- Integration branch name follows the same convention: `feature/<epic-id>-<description>`
+- The integration branch is created from `main` at the time the epic is planned
+- A PR from the integration branch to `main` is opened once all sub-issues are merged and tested
 
 ### When you are running as an agent in a worktree
 
 - You are already on an isolated branch (initially named `claude/<worktree-name>`) — do not run `git checkout -b`
 - Rename the branch to follow the naming convention before pushing: `git branch -m <label>/<issue-id>-<description>`
+- Before committing, run `swiftformat .` then `swiftlint` and resolve any errors
 - Commit and push your changes to that branch
-- Open a PR targeting `main` with `Closes #<issue-id>` in the description
+- Open a PR targeting the epic's integration branch (provided in your task prompt) or `main` if there is no epic
+- Include `Closes #<issue-id>` in the PR description
 
 ### Issue-to-agent routing
 


### PR DESCRIPTION
## Summary
- Agents now run `swiftformat .` and `swiftlint` before committing, preventing CI failures like the one in PR #168
- Epics now get an integration branch (`feature/<epic-id>-<description>`) created at planning time; sub-issue PRs target this branch instead of `main`, making it easy to build and test the full feature together before merging to `main`
- `github-project-planner` updated to create the integration branch and draft PR as part of the Execute step, and to embed the integration branch name in each sub-issue for implementing agents

## Test plan
- [x] Plan a new epic and verify `github-project-planner` creates the integration branch and draft PR
- [x] Implement a sub-issue and verify the agent targets the integration branch
- [x] Verify agents run SwiftFormat/SwiftLint before pushing

🤖 Generated with [Claude Code](https://claude.com/claude-code)