### PR TITLE
Add design system reference documentation

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,0 +1,287 @@
+# Design System
+
+This document is the authoritative reference for Cove's design system. It maps Figma design tokens and components to their Swift equivalents so that all UI work — by humans or agents — stays consistent.
+
+**Figma file:** [Cove](https://www.figma.com/design/PQWPBacMcEeXzDyi7aalZY/Cove)
+
+---
+
+## Figma File Structure
+
+| Page | Purpose |
+|---|---|
+| Cover | Title page |
+| Styles | Raw swatches and style references |
+| Components | All component definitions (source of truth for UI components) |
+| Views | Full screen mockups using component instances |
+| Color | Color token reference sheet |
+| Typography | Type scale reference sheet |
+| Spacing & Radius | Spacing and corner radius token reference sheet |
+| Playground | Experimental / scratch area |
+
+### Variable Collections
+
+| Collection | Purpose |
+|---|---|
+| `Primitives` | Raw values — hex colors, not used directly in UI |
+| `Color` | Semantic color tokens aliased from Primitives |
+| `Spacing` | 4pt-grid spacing tokens |
+| `Radius` | Corner radius tokens |
+
+---
+
+## Color System
+
+Colors live in two places that must stay in sync:
+
+- **Figma:** `Color` variable collection (semantic tokens aliased from `Primitives`)
+- **Swift:** Asset catalog at `Cove/Resources/Assets.xcassets/Colors/`
+
+The asset catalog folder structure maps directly to Swift: `Colors/Fills/primary.colorset` → `Color.Colors.Fills.primary`.
+
+> **Rule:** Always use semantic tokens. Never hardcode hex values or use `Color(.black)` / `Color(.white)`.
+
+### Fills
+
+Used for backgrounds of UI elements (cards, sheets, buttons, overlays).
+
+| Figma variable | Swift | Value / Meaning |
+|---|---|---|
+| `fills/primary` | `Color.Colors.Fills.primary` | `#52331F` — dark brown, primary surface |
+| `fills/inverse` | `Color.Colors.Fills.secondary` | `#FFFFFF` — white, on-dark surfaces ¹ |
+| `fills/secondary` | — | `#2B2627` — charcoal, secondary surface ¹ |
+| `fills/tertiary` | `Color.Colors.Fills.tertiary` | Charcoal 60% opacity |
+| `fills/quaternary` | `Color.Colors.Fills.quaternary` | Charcoal 30% opacity |
+| `fills/quinary` | `Color.Colors.Fills.quinary` | Charcoal 10% opacity |
+
+¹ The Figma variable was renamed (`secondary` → `inverse`, new `secondary` added) but the Swift colorset names have not been updated yet. Treat `Color.Colors.Fills.secondary` as the white/inverse fill until the asset catalog is updated.
+
+### Text
+
+Used for foreground text colors.
+
+| Figma variable | Swift | Value / Meaning |
+|---|---|---|
+| `text/primary` | `Color.Colors.Text.textPrimary` | `#52331F` — dark brown, primary text |
+| `text/inverse` | `Color.Colors.Text.textSecondary` | `#FFFFFF` — white text on dark backgrounds ¹ |
+| `text/tertiary` | `Color.Colors.Text.textTertiary` | Charcoal 60% opacity |
+| `text/quaternary` | — | Charcoal 30% opacity |
+| `text/quinary` | — | Charcoal 10% opacity |
+
+¹ Same naming drift as fills — `textSecondary` in Swift currently maps to white/inverse. Named constants for quaternary and quinary not yet added to the asset catalog.
+
+### Strokes
+
+Used for borders and dividers.
+
+| Figma variable | Swift | Value / Meaning |
+|---|---|---|
+| `strokes/primary` | `Color.Colors.Strokes.primary` | `#52331F` — dark brown border |
+| `strokes/secondary` | `Color.Colors.Strokes.secondary` | `#2B2627` — charcoal border |
+
+### Brand
+
+Brand palette colors used for identity, accents, and category expression.
+
+| Figma variable | Swift | Value / Meaning |
+|---|---|---|
+| `brand/primary` | `Color.Colors.Brand.Palette.primary` | `#52331F` — dark brown |
+| `brand/secondary` | `Color.Colors.Brand.Palette.secondary` | `#FFFFFF` — white |
+| `brand/accent` | `Color.Colors.Brand.accent` | `#E29547` — amber, interactive accent |
+| `brand/coral` | `Color.Colors.Brand.Palette.red` | `#FF8181` — coral ¹ |
+| `brand/amber` | `Color.Colors.Brand.Palette.orange` | `#FFB557` — amber ¹ |
+| `brand/yellow` | `Color.Colors.Brand.Palette.yellow` | `#FFFAA0` — yellow |
+| `brand/sage` | `Color.Colors.Brand.Palette.green` | `#8BA96A` — sage green ¹ |
+| `brand/blue` | `Color.Colors.Brand.Palette.blue` | `#6CA8D0` — blue |
+| `brand/violet` | `Color.Colors.Brand.Palette.violet` | `#D3C6FF` — violet |
+
+¹ Figma variables were renamed (red→coral, orange→amber, green→sage) but Swift asset names have not been updated yet.
+
+### Backgrounds
+
+Page-level background colors.
+
+| Figma variable | Swift | Value / Meaning |
+|---|---|---|
+| `backgrounds/primary` | `Color.Colors.Backgrounds.primary` | Off-white warm background |
+| `backgrounds/secondary` | `Color.Colors.Backgrounds.secondary` | Slightly darker warm background |
+
+### Category
+
+Used to tint the coffee category tiles.
+
+| Figma variable | Swift | Value / Meaning |
+|---|---|---|
+| `category/fruity` | `Color.Colors.Category.fruity` | Warm pink-red |
+| `category/choco` | `Color.Colors.Category.choco` | Warm brown |
+| `category/citrus` | `Color.Colors.Category.citrus` | Golden yellow |
+| `category/earthy` | `Color.Colors.Category.earthy` | Muted green-grey |
+| `category/floral` | `Color.Colors.Category.floral` | Soft lavender |
+
+### Feedback
+
+| Figma variable | Swift | Value / Meaning |
+|---|---|---|
+| `feedback/star` | `Color.Colors.Feedback.star` | `#FFC107` — star rating yellow |
+
+### Support *(Figma only — not yet in Swift asset catalog)*
+
+Used for alerts, banners, and status indicators.
+
+| Figma variable | Swift (pending) | Value |
+|---|---|---|
+| `support/success/default` | `Color.Colors.Support.Success.default` | `#8BA96A` — sage |
+| `support/success/fg` | `Color.Colors.Support.Success.fg` | `#4A6B35` — dark sage |
+| `support/success/surface` | `Color.Colors.Support.Success.surface` | `#EEF5E8` — light sage |
+| `support/warning/default` | `Color.Colors.Support.Warning.default` | `#FFB557` — amber |
+| `support/warning/fg` | `Color.Colors.Support.Warning.fg` | `#8C5E00` — dark amber |
+| `support/warning/surface` | `Color.Colors.Support.Warning.surface` | `#FFF4E0` — light amber |
+| `support/error/default` | `Color.Colors.Support.Error.default` | `#FF8181` — coral |
+| `support/error/fg` | `Color.Colors.Support.Error.fg` | `#B83232` — dark coral |
+| `support/error/surface` | `Color.Colors.Support.Error.surface` | `#FFF0F0` — light coral |
+
+When implementing alerts or status UI, add these colorsets to the asset catalog first, then use `Color.Colors.Support.*`.
+
+### Shadow color
+
+| Swift | Value |
+|---|---|
+| `Color.Colors.shadow` | `#1F1F1F` at 10% opacity |
+
+---
+
+## Typography
+
+Font files live in `Cove/Resources/`. Always use `Font.custom()` — never use system fonts for content text.
+
+### Type Scale
+
+| Figma style | Font | Size | Swift usage |
+|---|---|---|---|
+| Gazpacho/Display | Gazpacho-Black | 34pt | `Font.custom("Gazpacho-Black", size: 34)` |
+| Gazpacho/Heading XL | Gazpacho-Black | 28pt | `Font.custom("Gazpacho-Black", size: 28)` |
+| Gazpacho/Heading LG | Gazpacho-Black | 22pt | `Font.custom("Gazpacho-Black", size: 22)` |
+| Gazpacho/Heading MD | Gazpacho-Black | 18pt | `Font.custom("Gazpacho-Black", size: 18)` |
+| Gazpacho/Heading SM | Gazpacho-Black | 15pt | `Font.custom("Gazpacho-Black", size: 15)` |
+| Lato/Body LG | Lato-Bold | 16pt | `Font.custom("Lato-Bold", size: 16)` |
+| Lato/Body MD | Lato-Regular | 14pt | `Font.custom("Lato-Regular", size: 14)` |
+| Lato/Body SM | Lato-Regular | 12pt | `Font.custom("Lato-Regular", size: 12)` |
+| Lato/Caption | Lato-Regular | 10pt | `Font.custom("Lato-Regular", size: 10)` |
+
+### Rules
+
+- **Headings / display text:** Gazpacho-Black
+- **Body / UI text:** Lato-Regular (default) or Lato-Bold (emphasis)
+- **Poppins is removed** — do not use `Poppins-Regular` or `Poppins-SemiBold` anywhere
+
+---
+
+## Spacing
+
+Based on a **4pt grid**. No named Swift constants exist yet — use the raw values. Match to the token name in comments where helpful.
+
+| Figma token | Value | Primary use |
+|---|---|---|
+| `spacing/xs` | 4pt | Icon/label gap, tight component internals |
+| `spacing/sm` | 8pt | Label → input gap, icon margins, badge padding |
+| `spacing/md` | 12pt | Between components in a group, cell padding |
+| `spacing/lg` | 16pt | Screen edge inset, row vertical padding, card internals |
+| `spacing/xl` | 20pt | Between form fields, button vertical padding |
+| `spacing/2xl` | 24pt | Card-to-card gap, section breathing room |
+| `spacing/3xl` | 32pt | Major section separators, modal padding |
+| `spacing/4xl` | 48pt | Hero spacing, top-of-screen clearance |
+
+```swift
+// Until named constants exist, annotate with the token name:
+.padding(.horizontal, 16) // spacing/lg
+.padding(.bottom, 24)     // spacing/2xl
+```
+
+---
+
+## Corner Radius
+
+Based on a **2pt step** at smaller sizes. No named Swift constants exist yet — use raw values.
+
+| Figma token | Value | Primary use |
+|---|---|---|
+| `radius/none` | 0pt | Dividers, full-width elements |
+| `radius/xs` | 2pt | Tags, badges, small chips |
+| `radius/sm` | 4pt | Input fields, tooltips |
+| `radius/md` | 8pt | Buttons, list rows, image thumbnails |
+| `radius/lg` | 10pt | Cards, sheets, action menus |
+| `radius/xl` | 16pt | Large cards, modals, featured banners |
+| `radius/full` | 9999pt | Pills, avatar chips, toggle tracks |
+
+```swift
+.cornerRadius(8)  // radius/md — buttons, rows
+.cornerRadius(10) // radius/lg — cards, sheets
+```
+
+---
+
+## Shadow
+
+A 5-layer compound shadow defined in `Cove/Styles/CustomShadow.swift`. Apply with the `.customShadow()` modifier.
+
+**Figma:** Effect style `Shadow/Custom`
+
+```swift
+SomeView()
+    .customShadow()
+```
+
+The shadow layers (outermost to innermost):
+
+| Opacity | Radius | Y offset |
+|---|---|---|
+| 0% | 5 | 16 |
+| 1% | 4 | 10 |
+| 2% | 3 | 6 |
+| 3% | 3 | 3 |
+| 4% | 1 | 1 |
+
+---
+
+## Components
+
+All components are defined in the **Components page** of the Figma file. Views should use instances of these components, not detached copies.
+
+| Figma component | Swift file(s) | Notes |
+|---|---|---|
+| Buttons / Primary | `Cove/Styles/PrimaryButton.swift` | `PrimitiveButtonStyle`, uses `fills/primary` + `fills/inverse` |
+| Buttons / Secondary | `Cove/Styles/SecondaryButton.swift` | Outlined style, uses `strokes/primary` |
+| Buttons / Banner | `Cove/Components/BannerButton.swift` | Used inside promotional banners |
+| Buttons / Social Login | `Cove/Components/` | Google, Facebook, Apple variants |
+| Text Field | `Cove/Components/` | Email, password, search, text area variants |
+| Section Header | `Cove/Components/` | Title + optional "See all →" in `brand/accent` |
+| Divider | `Cove/Components/` | Plain line and "OR" variants |
+| Card / Product | `Cove/Components/ProductCardView.swift` | Product image, name, roaster, price |
+| Card / Category | `Cove/Components/CoffeeCategoryButton.swift` | Uses `category/*` fill colors |
+| Bag Item | `Cove/Components/` | Quantity stepper in `brand/accent`, price in `text/primary` |
+| Store Card | `Cove/Components/` | Circular logo + store name |
+| Promotional Banner | `Cove/Components/` | Two variants: full-bleed image and compact |
+| Hero Art | `Cove/Resources/` | Illustrative identity tiles — fixed colors by design |
+| Tiles | `Cove/Resources/` | Decorative loading indicator tiles — fixed colors by design |
+| Icons | `Cove/Resources/` | Social auth icons — third-party brand colors, intentionally fixed |
+
+---
+
+## Rules & Anti-Patterns
+
+### Always
+
+- Use `Color.Colors.*` for all colors
+- Use `Font.custom("Gazpacho-Black" / "Lato-Bold" / "Lato-Regular", size:)` for all text
+- Use `.customShadow()` for card/sheet elevation
+- Use spacing values from the 4pt grid
+- Use corner radius values from the token scale
+- Use component instances from the Figma Components page, not detached copies
+
+### Never
+
+- Hardcode hex values: `Color(hex: "#52331F")` ✗
+- Use system fonts for content: `.font(.body)` or `.font(.headline)` ✗
+- Use Poppins: `Font.custom("Poppins-Regular", ...)` ✗
+- Use pure black or white: `Color.black` / `Color.white` ✗ — use `fills/primary` and `fills/inverse`
+- Detach Figma component instances before implementing

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -178,7 +178,9 @@ Font files live in `Cove/Resources/`. Always use `Font.custom()` — never use s
 
 ## Spacing
 
-Based on a **4pt grid**. No named Swift constants exist yet — use the raw values. Match to the token name in comments where helpful.
+Based on a **4pt grid**. Spacing tokens are defined in the `Spacing` Figma variable collection but **named Swift constants do not exist yet** — the codebase currently uses raw `CGFloat` values throughout.
+
+> **Pending parity work:** A `Spacing` enum or extension should be added to the Swift codebase so that hardcoded values like `16`, `24`, `32` can be replaced with named constants that match the Figma token names. Until then, annotate raw values with the token name in a comment so the intent is clear and the future refactor is easy to grep for.
 
 | Figma token | Value | Primary use |
 |---|---|---|
@@ -192,16 +194,22 @@ Based on a **4pt grid**. No named Swift constants exist yet — use the raw valu
 | `spacing/4xl` | 48pt | Hero spacing, top-of-screen clearance |
 
 ```swift
-// Until named constants exist, annotate with the token name:
+// Current practice — annotate raw values with the token name:
 .padding(.horizontal, 16) // spacing/lg
 .padding(.bottom, 24)     // spacing/2xl
+
+// Target state once Swift constants are added:
+// .padding(.horizontal, Spacing.lg)
+// .padding(.bottom, Spacing.x2l)
 ```
 
 ---
 
 ## Corner Radius
 
-Based on a **2pt step** at smaller sizes. No named Swift constants exist yet — use raw values.
+Based on a **2pt step** at smaller sizes. Radius tokens are defined in the `Radius` Figma variable collection but **named Swift constants do not exist yet** — the codebase currently uses raw `CGFloat` values.
+
+> **Pending parity work:** A `Radius` enum or extension should be added to match the Figma token names. Until then, annotate raw values with the token name in a comment.
 
 | Figma token | Value | Primary use |
 |---|---|---|
@@ -214,8 +222,13 @@ Based on a **2pt step** at smaller sizes. No named Swift constants exist yet —
 | `radius/full` | 9999pt | Pills, avatar chips, toggle tracks |
 
 ```swift
+// Current practice — annotate raw values with the token name:
 .cornerRadius(8)  // radius/md — buttons, rows
 .cornerRadius(10) // radius/lg — cards, sheets
+
+// Target state once Swift constants are added:
+// .cornerRadius(Radius.md)
+// .cornerRadius(Radius.lg)
 ```
 
 ---
@@ -285,3 +298,27 @@ All components are defined in the **Components page** of the Figma file. Views s
 - Use Poppins: `Font.custom("Poppins-Regular", ...)` ✗
 - Use pure black or white: `Color.black` / `Color.white` ✗ — use `fills/primary` and `fills/inverse`
 - Detach Figma component instances before implementing
+
+---
+
+## Roadmap & Known Gaps
+
+Outstanding work to achieve full parity between Figma and Swift:
+
+| Area | Status | Action needed |
+|---|---|---|
+| Spacing constants | ⏳ Pending | Add a `Spacing` enum/extension with named values matching `spacing/*` tokens |
+| Radius constants | ⏳ Pending | Add a `Radius` enum/extension with named values matching `radius/*` tokens |
+| Support colors | ⏳ Pending | Add `Colors/Support/` colorsets to the asset catalog for all 9 `support/*` tokens |
+| Color naming drift | ⏳ Pending | Rename Swift colorsets to match updated Figma variable names (`secondary` → `inverse`, `textSecondary` → `textInverse`, brand palette names) |
+| Codebase realignment | ⏳ Pending | Full pass through all Views and Components to replace hardcoded colors, fonts, spacing, and radius values with design system tokens |
+
+### Codebase realignment pass
+
+The next major design system milestone is a full sweep of the codebase to bring all existing UI code into alignment with these tokens. This includes:
+
+- Replace any remaining hardcoded colors with `Color.Colors.*`
+- Replace any remaining raw spacing values with annotated constants (and eventually named `Spacing.*` calls)
+- Replace any remaining raw corner radius values with annotated constants
+- Replace any remaining `Poppins` font references with `Lato`
+- Verify all views use component instances rather than inline reimplementations

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the documentation for the Cove iOS app.
   - Build and run instructions
 
 ### App
+- **[Design System](DESIGN_SYSTEM.md)** - Color tokens, typography, spacing, radius, shadow, and Figma↔Swift component mapping
 - **[App Architecture](APP_ARCHITECTURE.md)** - How the app is structured and how data flows
   - MVVM pattern and ViewModels
   - Authentication and navigation
@@ -46,6 +47,9 @@ Welcome to the documentation for the Cove iOS app.
 
 ### I want to understand how the app works
 → Read [App Architecture](APP_ARCHITECTURE.md)
+
+### I'm implementing UI and need color/font/spacing tokens
+→ Read [Design System](DESIGN_SYSTEM.md)
 
 ### I need to configure CI/CD secrets
 → Follow [Secrets Setup Guide](SECRETS_SETUP.md)


### PR DESCRIPTION
## Summary

- Adds `docs/DESIGN_SYSTEM.md` — a comprehensive reference mapping the Figma design system to Swift code
- Updates `docs/README.md` to link the new doc and add a "I'm implementing UI" routing entry

## What's in the doc

- **Figma file structure** — pages and variable collections overview
- **Color system** — full token table mapping every Figma variable (`fills/*`, `text/*`, `strokes/*`, `brand/*`, `backgrounds/*`, `category/*`, `feedback/*`, `support/*`) to its Swift `Color.Colors.*` access path, with notes on current naming drift between Figma (updated) and the Swift asset catalog (not yet renamed)
- **Typography** — complete 9-step type scale with exact `Font.custom()` strings for Gazpacho-Black and Lato
- **Spacing** — 4pt-grid token table with use-case guidance per step
- **Corner radius** — token table with primary use cases per step
- **Shadow** — `.customShadow()` modifier reference
- **Component map** — Figma component → Swift file mapping for all 14 components
- **Rules & anti-patterns** — explicit "always/never" list covering hardcoded colors, system fonts, Poppins, pure black/white, and detached component copies

## Reviewer notes

- The "naming drift" callouts in the color section are intentional — they document the current gap between Figma variables (renamed this session) and the Swift asset catalog (not yet updated). This is a known future task.
- Support color tokens (`support/success/*`, `support/warning/*`, `support/error/*`) are documented with their pending Swift paths — they exist in Figma but haven't been added to the asset catalog yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)