### PR TITLE
Add support color tokens to Swift asset catalog

### DIFF
--- a/Cove/Resources/Assets.xcassets/Colors/Support/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Error/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Error/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Error/fg.colorset/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Error/fg.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x32",
+          "green" : "0x32",
+          "red" : "0xB8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Error/fill.colorset/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Error/fill.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x81",
+          "green" : "0x81",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Error/surface.colorset/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Error/surface.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF0",
+          "green" : "0xF0",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Success/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Success/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Success/fg.colorset/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Success/fg.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x35",
+          "green" : "0x6B",
+          "red" : "0x4A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Success/fill.colorset/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Success/fill.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6A",
+          "green" : "0xA9",
+          "red" : "0x8B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Success/surface.colorset/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Success/surface.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE8",
+          "green" : "0xF5",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Warning/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Warning/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Warning/fg.colorset/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Warning/fg.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x5E",
+          "red" : "0x8C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Warning/fill.colorset/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Warning/fill.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x57",
+          "green" : "0xB5",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cove/Resources/Assets.xcassets/Colors/Support/Warning/surface.colorset/Contents.json
+++ b/Cove/Resources/Assets.xcassets/Colors/Support/Warning/surface.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE0",
+          "green" : "0xF4",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -124,23 +124,23 @@ Used to tint the coffee category tiles.
 |---|---|---|
 | `feedback/star` | `Color.Colors.Feedback.star` | `#FFC107` — star rating yellow |
 
-### Support *(Figma only — not yet in Swift asset catalog)*
+### Support
 
 Used for alerts, banners, and status indicators.
 
-| Figma variable | Swift (pending) | Value |
+> **Naming note:** The Figma variable is named `support/*/default` but Swift's `default` is a reserved keyword. The Swift colorset uses `fill` instead.
+
+| Figma variable | Swift | Value |
 |---|---|---|
-| `support/success/default` | `Color.Colors.Support.Success.default` | `#8BA96A` — sage |
+| `support/success/default` | `Color.Colors.Support.Success.fill` | `#8BA96A` — sage |
 | `support/success/fg` | `Color.Colors.Support.Success.fg` | `#4A6B35` — dark sage |
 | `support/success/surface` | `Color.Colors.Support.Success.surface` | `#EEF5E8` — light sage |
-| `support/warning/default` | `Color.Colors.Support.Warning.default` | `#FFB557` — amber |
+| `support/warning/default` | `Color.Colors.Support.Warning.fill` | `#FFB557` — amber |
 | `support/warning/fg` | `Color.Colors.Support.Warning.fg` | `#8C5E00` — dark amber |
 | `support/warning/surface` | `Color.Colors.Support.Warning.surface` | `#FFF4E0` — light amber |
-| `support/error/default` | `Color.Colors.Support.Error.default` | `#FF8181` — coral |
+| `support/error/default` | `Color.Colors.Support.Error.fill` | `#FF8181` — coral |
 | `support/error/fg` | `Color.Colors.Support.Error.fg` | `#B83232` — dark coral |
 | `support/error/surface` | `Color.Colors.Support.Error.surface` | `#FFF0F0` — light coral |
-
-When implementing alerts or status UI, add these colorsets to the asset catalog first, then use `Color.Colors.Support.*`.
 
 ### Shadow color
 
@@ -296,7 +296,7 @@ Outstanding work to achieve full parity between Figma and Swift:
 |---|---|---|
 | Spacing constants | ✅ Done | `Cove/Constants/Spacing.swift` |
 | Radius constants | ✅ Done | `Cove/Constants/Radius.swift` |
-| Support colors | ⏳ Pending | Add `Colors/Support/` colorsets to the asset catalog for all 9 `support/*` tokens |
+| Support colors | ✅ Done | `Cove/Resources/Assets.xcassets/Colors/Support/` |
 | Color naming drift | ⏳ Pending | Rename Swift colorsets to match updated Figma variable names (`secondary` → `inverse`, `textSecondary` → `textInverse`, brand palette names) |
 | Codebase realignment | ⏳ Pending | Full pass through all Views and Components to replace hardcoded colors, fonts, spacing, and radius values with design system tokens |
 


### PR DESCRIPTION
## Summary

- Adds `Colors/Support/Success/{fill,fg,surface}.colorset` — sage-based success colors
- Adds `Colors/Support/Warning/{fill,fg,surface}.colorset` — amber-based warning colors
- Adds `Colors/Support/Error/{fill,fg,surface}.colorset` — coral-based error colors
- Updates `docs/DESIGN_SYSTEM.md` — Support section updated with correct Swift paths, roadmap item marked done

## Color values

| Token | Hex | Use |
|---|---|---|
| Success fill | `#8BA96A` | Background for success states |
| Success fg | `#4A6B35` | Text/icon on success surfaces |
| Success surface | `#EEF5E8` | Container background |
| Warning fill | `#FFB557` | Background for warning states |
| Warning fg | `#8C5E00` | Text/icon on warning surfaces |
| Warning surface | `#FFF4E0` | Container background |
| Error fill | `#FF8181` | Background for error states |
| Error fg | `#B83232` | Text/icon on error surfaces |
| Error surface | `#FFF0F0` | Container background |

## Naming note

Figma uses `support/*/default` but `default` is a reserved Swift keyword. The colorset is named `fill` instead — documented in DESIGN_SYSTEM.md.

## Test plan

- [x] Project builds with no missing asset warnings
- [x] `Color.Colors.Support.Success.fill` resolves correctly in Xcode

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)