### PR TITLE
Remove Poppins font and replace with Lato

### DIFF
--- a/Cove/Components/CoffeeCategoryButton.swift
+++ b/Cove/Components/CoffeeCategoryButton.swift
@@ -31,7 +31,7 @@ struct CoffeeCategoryButton: View {
                         )
                     )
                 Text(category)
-                    .font(Font.custom("Poppins-Regular", size: 16))
+                    .font(Font.custom("Lato-Regular", size: 16))
                     .offset(x: -32, y: 0)
             }
             .frame(width: 140, height: 65)
@@ -56,7 +56,7 @@ struct CoffeeCategoryButton: View {
                         )
                     )
                 Text(category)
-                    .font(Font.custom("Poppins-Regular", size: 14))
+                    .font(Font.custom("Lato-Regular", size: 14))
                     .offset(x: -32, y: 0)
             }
             .frame(width: 140, height: 65)
@@ -81,7 +81,7 @@ struct CoffeeCategoryButton: View {
                         )
                     )
                 Text(category)
-                    .font(Font.custom("Poppins-Regular", size: 14))
+                    .font(Font.custom("Lato-Regular", size: 14))
                     .offset(x: -32, y: 0)
             }
             .frame(width: 140, height: 65)
@@ -106,7 +106,7 @@ struct CoffeeCategoryButton: View {
                         )
                     )
                 Text(category)
-                    .font(Font.custom("Poppins-Regular", size: 14))
+                    .font(Font.custom("Lato-Regular", size: 14))
                     .offset(x: -32, y: 0)
             }
             .frame(width: 140, height: 65)
@@ -131,7 +131,7 @@ struct CoffeeCategoryButton: View {
                         )
                     )
                 Text(category)
-                    .font(Font.custom("Poppins-Regular", size: 14))
+                    .font(Font.custom("Lato-Regular", size: 14))
                     .offset(x: -32, y: 0)
             }
             .frame(width: 140, height: 65)

--- a/Cove/Components/LargeButton.swift
+++ b/Cove/Components/LargeButton.swift
@@ -22,7 +22,7 @@ struct LargeButton: View {
                 }
                 .overlay(alignment: .topLeading) {
                     Text(category)
-                        .font(Font.custom("Poppins-Regular", size: 14))
+                        .font(Font.custom("Lato-Regular", size: 14))
                         .padding(10)
                 }
                 .frame(width: 140, height: 200)
@@ -38,7 +38,7 @@ struct LargeButton: View {
                 }
                 .overlay(alignment: .topLeading) {
                     Text(category)
-                        .font(Font.custom("Poppins-Regular", size: 14))
+                        .font(Font.custom("Lato-Regular", size: 14))
                         .padding(10)
                 }
                 .frame(width: 140, height: 200)
@@ -55,7 +55,7 @@ struct LargeButton: View {
                 }
                 .overlay(alignment: .topLeading) {
                     Text(category)
-                        .font(Font.custom("Poppins-Regular", size: 14))
+                        .font(Font.custom("Lato-Regular", size: 14))
                         .padding(10)
                 }
                 .frame(width: 140, height: 200)
@@ -73,7 +73,7 @@ struct LargeButton: View {
                 }
                 .overlay(alignment: .topLeading) {
                     Text(category)
-                        .font(Font.custom("Poppins-Regular", size: 14))
+                        .font(Font.custom("Lato-Regular", size: 14))
                         .padding(10)
                 }
                 .background(Color(red: 255 / 255, green: 252 / 255, blue: 246 / 255))
@@ -91,7 +91,7 @@ struct LargeButton: View {
                 }
                 .overlay(alignment: .topLeading) {
                     Text(category)
-                        .font(Font.custom("Poppins-Regular", size: 14))
+                        .font(Font.custom("Lato-Regular", size: 14))
                         .padding(10)
                 }
                 .background(Color(red: 255 / 255, green: 252 / 255, blue: 246 / 255))

--- a/Cove/Components/OriginButton.swift
+++ b/Cove/Components/OriginButton.swift
@@ -24,7 +24,7 @@ struct OriginButton: View {
                 }
                 .overlay(alignment: .topLeading) {
                     Text(origin)
-                        .font(Font.custom("Poppins-Regular", size: 14))
+                        .font(Font.custom("Lato-Regular", size: 14))
                         .padding(10)
                 }
                 .frame(width: 140, height: 200)
@@ -40,7 +40,7 @@ struct OriginButton: View {
                 }
                 .overlay(alignment: .topLeading) {
                     Text(origin)
-                        .font(Font.custom("Poppins-Regular", size: 14))
+                        .font(Font.custom("Lato-Regular", size: 14))
                         .padding(10)
                 }
                 .frame(width: 140, height: 200)
@@ -56,7 +56,7 @@ struct OriginButton: View {
                 }
                 .overlay(alignment: .topLeading) {
                     Text(origin)
-                        .font(Font.custom("Poppins-Regular", size: 14))
+                        .font(Font.custom("Lato-Regular", size: 14))
                         .padding(10)
                 }
                 .frame(width: 140, height: 200)
@@ -72,7 +72,7 @@ struct OriginButton: View {
                 }
                 .overlay(alignment: .topLeading) {
                     Text(origin)
-                        .font(Font.custom("Poppins-Regular", size: 14))
+                        .font(Font.custom("Lato-Regular", size: 14))
                         .padding(10)
                 }
                 .frame(width: 140, height: 200)
@@ -89,7 +89,7 @@ struct OriginButton: View {
                 }
                 .overlay(alignment: .topLeading) {
                     Text(origin)
-                        .font(Font.custom("Poppins-Regular", size: 14))
+                        .font(Font.custom("Lato-Regular", size: 14))
                         .padding(10)
                 }
                 .frame(width: 140, height: 200)

--- a/Cove/Components/ProductRow.swift
+++ b/Cove/Components/ProductRow.swift
@@ -30,10 +30,10 @@ struct ProductRow: View {
 
                 VStack(alignment: .leading) {
                     Text(coffeeProduct.info.name)
-                        .font(Font.custom("Poppins-Regular", size: 12))
+                        .font(Font.custom("Lato-Regular", size: 12))
                         .foregroundStyle(Color.Colors.Fills.primary)
                     Text(coffeeProduct.info.roastery)
-                        .font(Font.custom("Poppins-Regular", size: 12))
+                        .font(Font.custom("Lato-Regular", size: 12))
                         .foregroundStyle(Color.Colors.Fills.tertiary)
 
                     Spacer()
@@ -52,7 +52,7 @@ struct ProductRow: View {
                         .disabled(bagProduct.quantity == 1 ? true : false)
 
                         Text(String(bagProduct.quantity))
-                            .font(Font.custom("Poppins-Regular", size: 14))
+                            .font(Font.custom("Lato-Regular", size: 14))
                             .frame(width: 30, height: 20)
 
                         Button {
@@ -79,7 +79,7 @@ struct ProductRow: View {
 //                        .frame(width: 20)
                     Spacer()
                     Text("$\(String(Int(coffeeProduct.defaultPrice)))")
-                        .font(Font.custom("Poppins-SemiBold", size: 16))
+                        .font(Font.custom("Lato-Bold", size: 16))
                         .foregroundStyle(Color.Colors.Fills.primary)
                 }
             }
@@ -101,10 +101,10 @@ struct ProductRow: View {
 
                 VStack(alignment: .leading) {
                     Text(musicProduct.info.album)
-                        .font(Font.custom("Poppins-Regular", size: 12))
+                        .font(Font.custom("Lato-Regular", size: 12))
                         .foregroundStyle(Color.Colors.Fills.primary)
                     Text(musicProduct.info.artist)
-                        .font(Font.custom("Poppins-Regular", size: 12))
+                        .font(Font.custom("Lato-Regular", size: 12))
                         .foregroundStyle(Color.Colors.Fills.tertiary)
 
                     Spacer()
@@ -123,7 +123,7 @@ struct ProductRow: View {
                         .disabled(bagProduct.quantity == 1 ? true : false)
 
                         Text(String(bagProduct.quantity))
-                            .font(Font.custom("Poppins-Regular", size: 14))
+                            .font(Font.custom("Lato-Regular", size: 14))
                             .frame(width: 30, height: 20)
 
                         Button {
@@ -150,7 +150,7 @@ struct ProductRow: View {
 //                        .frame(width: 20)
                     Spacer()
                     Text("$\(String(Int(musicProduct.defaultPrice)))")
-                        .font(Font.custom("Poppins-SemiBold", size: 16))
+                        .font(Font.custom("Lato-Bold", size: 16))
                         .foregroundStyle(Color.Colors.Fills.primary)
                 }
             }
@@ -172,10 +172,10 @@ struct ProductRow: View {
 
                 VStack(alignment: .leading) {
                     Text(apparelProduct.info.name)
-                        .font(Font.custom("Poppins-Regular", size: 12))
+                        .font(Font.custom("Lato-Regular", size: 12))
                         .foregroundStyle(Color.Colors.Fills.primary)
                     Text(apparelProduct.info.brand)
-                        .font(Font.custom("Poppins-Regular", size: 12))
+                        .font(Font.custom("Lato-Regular", size: 12))
                         .foregroundStyle(Color.Colors.Fills.tertiary)
 
                     Spacer()
@@ -194,7 +194,7 @@ struct ProductRow: View {
                         .disabled(bagProduct.quantity == 1 ? true : false)
 
                         Text(String(bagProduct.quantity))
-                            .font(Font.custom("Poppins-Regular", size: 14))
+                            .font(Font.custom("Lato-Regular", size: 14))
                             .frame(width: 30, height: 20)
 
                         Button {
@@ -221,7 +221,7 @@ struct ProductRow: View {
 //                        .frame(width: 20)
                     Spacer()
                     Text("$\(String(Int(apparelProduct.defaultPrice)))")
-                        .font(Font.custom("Poppins-SemiBold", size: 16))
+                        .font(Font.custom("Lato-Bold", size: 16))
                         .foregroundStyle(Color.Colors.Fills.primary)
                 }
             }

--- a/Cove/Views/BagView.swift
+++ b/Cove/Views/BagView.swift
@@ -23,7 +23,7 @@ struct BagView: View {
             VStack(spacing: 20) {
                 HStack {
                     Text("My Shopping Bag")
-                        .font(Font.custom("Poppins-SemiBold", size: 26))
+                        .font(Font.custom("Lato-Bold", size: 26))
                         .padding(.top, 28)
                     Spacer()
                 }
@@ -35,7 +35,7 @@ struct BagView: View {
                         .overlay {
                             Text("Products you add to your bag can be found here!")
                                 .multilineTextAlignment(.center)
-                                .font(Font.custom("Poppins-Regular", size: 16))
+                                .font(Font.custom("Lato-Regular", size: 16))
                                 .foregroundStyle(Color.Colors.Fills.primary)
                                 .padding(50)
                         }
@@ -62,7 +62,7 @@ struct BagView: View {
 
                     HStack {
                         TextField("Insert your coupon code", text: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Value@*/ .constant("")/*@END_MENU_TOKEN@*/)
-                            .font(Font.custom("Poppins-Regular", size: 14))
+                            .font(Font.custom("Lato-Regular", size: 14))
                             .padding([.leading, .trailing])
                             .frame(maxHeight: .infinity)
                             .overlay {
@@ -86,7 +86,7 @@ struct BagView: View {
 
                 if !bag.bagProducts.isEmpty {
                     Text("Other products you might like")
-                        .font(Font.custom("Poppins-SemiBold", size: 18))
+                        .font(Font.custom("Lato-Bold", size: 18))
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding([.leading, .trailing], 20)
 
@@ -114,10 +114,10 @@ struct BagView: View {
                 HStack {
                     VStack(alignment: .leading) {
                         Text("Total")
-                            .font(Font.custom("Poppins-Regular", size: 14))
+                            .font(Font.custom("Lato-Regular", size: 14))
                             .foregroundStyle(Color.Colors.Fills.tertiary)
                         Text("$\(bag.total)")
-                            .font(Font.custom("Poppins-SemiBold", size: 20))
+                            .font(Font.custom("Lato-Bold", size: 20))
                             .foregroundStyle(Color.Colors.Brand.accent)
                     }
 

--- a/Cove/Views/FavoritesView.swift
+++ b/Cove/Views/FavoritesView.swift
@@ -17,7 +17,7 @@ struct FavoritesView: View {
             VStack(spacing: 20) {
                 HStack {
                     Text("My Favorites")
-                        .font(Font.custom("Poppins-SemiBold", size: 26))
+                        .font(Font.custom("Lato-Bold", size: 26))
                         .padding(.top, 28)
                     Spacer()
                 }
@@ -33,7 +33,7 @@ struct FavoritesView: View {
                         .overlay {
                             Text("Products you save will appear here")
                                 .multilineTextAlignment(.center)
-                                .font(Font.custom("Poppins-Regular", size: 16))
+                                .font(Font.custom("Lato-Regular", size: 16))
                                 .foregroundStyle(Color.Colors.Fills.primary)
                                 .padding(50)
                         }


### PR DESCRIPTION
## Summary

- Replaces all 35 Poppins font references across 6 files
- `Poppins-Regular` → `Lato-Regular`, `Poppins-SemiBold` → `Lato-Bold`
- Font sizes unchanged

Files updated: `BagView`, `FavoritesView`, `LargeButton`, `OriginButton`, `CoffeeCategoryButton`, `ProductRow`

## Test plan

- [x] Build succeeds with no font-related warnings
- [x] All text renders correctly in affected views (no missing font fallback)
- [x] No remaining `Poppins` references in the codebase

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)