### PR TITLE
Replace hardcoded colors with design system tokens

### DIFF
--- a/Cove/Components/BannerButton.swift
+++ b/Cove/Components/BannerButton.swift
@@ -41,7 +41,7 @@ struct BannerButton: View {
                             }
                             .padding(14)
                             .frame(width: geometry.size.height - (11 * 2), height: geometry.size.height - (11 * 2))
-                            .background(.white)
+                            .background(Color.Colors.Fills.secondary)
                             .foregroundStyle(Color.Colors.Fills.primary)
                             .cornerRadius(8)
                         }

--- a/Cove/Components/EmailField.swift
+++ b/Cove/Components/EmailField.swift
@@ -16,15 +16,15 @@ struct EmailField: View {
             Text("Email")
                 .font(.custom("Lato-Bold", size: 12))
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .foregroundStyle(.black.opacity(0.5))
+                .foregroundStyle(Color.Colors.Text.textTertiary)
             TextField(String("email@example.com"), text: $text)
                 .font(.custom("Lato-Regular", size: 14))
                 .padding()
                 .frame(maxWidth: .infinity, maxHeight: 50)
-                .background(Color.white)
+                .background(Color.Colors.Fills.secondary)
                 .overlay(
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .strokeBorder(Color.black, lineWidth: 1)
+                        .strokeBorder(Color.Colors.Strokes.primary, lineWidth: 1)
                 )
                 .focused($focus, equals: Field.email)
                 .onTapGesture {

--- a/Cove/Components/LargeButton.swift
+++ b/Cove/Components/LargeButton.swift
@@ -76,7 +76,7 @@ struct LargeButton: View {
                         .font(Font.custom("Poppins-Regular", size: 14))
                         .padding(10)
                 }
-                .background(Color(red: 255 / 255, green: 252 / 255, blue: 246 / 255))
+                .background(Color.Colors.Backgrounds.primary)
                 .frame(width: 140, height: 200)
                 .cornerRadius(8)
         default:
@@ -94,7 +94,7 @@ struct LargeButton: View {
                         .font(Font.custom("Poppins-Regular", size: 14))
                         .padding(10)
                 }
-                .background(Color(red: 255 / 255, green: 252 / 255, blue: 246 / 255))
+                .background(Color.Colors.Backgrounds.primary)
                 .frame(width: 140, height: 200)
                 .cornerRadius(8)
         }

--- a/Cove/Components/SmallCategoryButton.swift
+++ b/Cove/Components/SmallCategoryButton.swift
@@ -67,7 +67,7 @@ struct SmallCategoryButton: View {
         case "Bevs":
             Rectangle()
                 .overlay {
-                    Color(UIColor(red: 255 / 255, green: 252 / 255, blue: 247 / 255, alpha: 1))
+                    Color.Colors.Backgrounds.primary
                     Image("58533a99308279.5ef03e3c0da5a")
                         .resizable()
                         .aspectRatio(contentMode: .fill)

--- a/Cove/Components/SmallSocialButton.swift
+++ b/Cove/Components/SmallSocialButton.swift
@@ -28,13 +28,13 @@ struct SmallSocialButton: View {
 
         switch self.socialType {
         case .apple:
-            color = .black
+            color = Color.Colors.Fills.primary
             imgName = "apple"
         case .facebook:
             color = Color(red: 0.376, green: 0.537, blue: 0.839)
             imgName = "facebook"
         case .google:
-            color = .white
+            color = Color.Colors.Fills.secondary
             imgName = "google"
         }
     }

--- a/Cove/Views/BagView.swift
+++ b/Cove/Views/BagView.swift
@@ -129,7 +129,7 @@ struct BagView: View {
                 .padding(.vertical, 16)
                 .padding(.horizontal, 20)
                 .background {
-                    Color.white.ignoresSafeArea()
+                    Color.Colors.Fills.secondary.ignoresSafeArea()
                 }
             }
         }

--- a/Cove/Views/ProductDetailView.swift
+++ b/Cove/Views/ProductDetailView.swift
@@ -24,7 +24,7 @@ struct ProductDetailView: View {
     let productId: String
 
     @State private var uiImage: UIImage?
-    @State private var averageColor: Color = .white // Default background color
+    @State private var averageColor: Color = .Colors.Backgrounds.primary
 
     @State var count: Int = 1
 
@@ -186,7 +186,7 @@ private struct ProductDetailContent: View {
 
                             Circle()
                                 .frame(width: 35, height: 35)
-                                .foregroundStyle(.white)
+                                .foregroundStyle(Color.Colors.Fills.secondary)
                                 .overlay {
                                     Circle()
                                         .frame(width: 30, height: 30)
@@ -194,7 +194,7 @@ private struct ProductDetailContent: View {
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(16)
-                        .background(.white)
+                        .background(Color.Colors.Fills.secondary)
                         .clipShape(RoundedRectangle(cornerRadius: 10))
                         .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.Colors.Strokes.primary, lineWidth: 1))
                     }
@@ -216,7 +216,7 @@ private struct ProductDetailContent: View {
                 .padding(.top, 30)
                 .padding([.horizontal, .bottom], 20)
                 .background(
-                    Color.white
+                    Color.Colors.Fills.secondary
                         .padding(.bottom, -1000)
                 )
             }
@@ -278,7 +278,7 @@ private struct ProductDetailContent: View {
                 .padding(.vertical, 16)
                 .padding(.horizontal, 20)
                 .background {
-                    Color.white.ignoresSafeArea()
+                    Color.Colors.Fills.secondary.ignoresSafeArea()
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Replaces all bare `Color.white`, `Color.black`, and raw `UIColor(red:)` values with `Color.Colors.*` semantic tokens
- 7 files updated, 15 color references replaced

**Mapping applied:**

| Old | New |
|---|---|
| `Color.white` / `.white` | `Color.Colors.Fills.secondary` |
| `Color.black` / `.black` | `Color.Colors.Fills.primary` |
| `Color(red: 255/255, green: 252/255, blue: 246/255)` | `Color.Colors.Backgrounds.primary` |
| `UIColor(red: 255/255, green: 252/255, blue: 247/255)` | `Color.Colors.Backgrounds.primary` |
| `.black.opacity(0.5)` (label tint) | `Color.Colors.Text.textTertiary` |
| `Color.black` stroke | `Color.Colors.Strokes.primary` |

Facebook blue in `SmallSocialButton` is intentionally unchanged (third-party brand color).

## Test plan

- [x] Build succeeds with no color-related warnings
- [x] Social login buttons render correctly (Apple dark, Google white, Facebook blue)
- [x] Email field border and background correct
- [x] Bag and product detail bottom bars render with correct white surface
- [x] Bevs category tile background matches warm off-white

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)