### PR TITLE
Fix Xcode project format version for CI compatibility

### DIFF
--- a/Cove.xcodeproj/project.pbxproj
+++ b/Cove.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 100;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -140,7 +140,7 @@
 				D00DB7372FAB034900D56700 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				D00DB73C2FAB03FD00D56700 /* XCRemoteSwiftPackageReference "rive-ios" */,
 			);
-			preferredProjectObjectVersion = 100;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = D02B2FB327BD7E61004732CB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";


### PR DESCRIPTION
## Summary
- Downgrades `objectVersion` from `100` to `77` in `project.pbxproj`
- Downgrades `preferredProjectObjectVersion` from `100` to `77`
- The project was inadvertently saved in Xcode 26.3 format (version 100) during the SPM migration; the `macos-26` CI runner ships Xcode 26.2, which cannot open format 100

## Test plan
- [x] CI build passes on `macos-26` runner
- [x] Project opens cleanly in Xcode locally after the change

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)