### PR TITLE
Update docs to reflect CocoaPods to SPM migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The project also serves as a testbed for agentic development: using AI agents to
 | Language | Swift / SwiftUI |
 | Architecture | MVVM |
 | Backend | Firebase (Auth, Firestore, Cloud Storage) |
-| Dependencies | CocoaPods |
+| Dependencies | Swift Package Manager |
 | CI/CD | GitHub Actions + Fastlane |
 
 ## Getting Started
@@ -25,7 +25,6 @@ The project also serves as a testbed for agentic development: using AI agents to
 ### Prerequisites
 
 - **Xcode 16+** (required for iOS 18 SDK)
-- **CocoaPods** — `sudo gem install cocoapods`
 
 ### Setup
 
@@ -34,12 +33,11 @@ The project also serves as a testbed for agentic development: using AI agents to
 git clone https://github.com/danicajiao/cove-ios.git
 cd cove-ios
 
-# 2. Install CocoaPods dependencies
-pod install
-
-# 3. Open the workspace (not the .xcodeproj)
-open Cove.xcworkspace
+# 2. Open the project
+open Cove.xcodeproj
 ```
+
+Dependencies are managed via Swift Package Manager and resolve automatically when you open the project in Xcode.
 
 ### Firebase Configuration
 

--- a/docs/CI_CD_WORKFLOWS.md
+++ b/docs/CI_CD_WORKFLOWS.md
@@ -71,7 +71,7 @@ The Cove iOS app uses GitHub Actions for continuous integration and deployment f
 **Configuration:**
 - Runs on macOS-26
 - Uses Ruby 4.0.1 with bundler cache
-- Uses CocoaPods with caching
+- Uses Swift Package Manager (resolved automatically by xcodebuild)
 - Runs `bundle exec fastlane build` and `bundle exec fastlane test`
 
 **Note:** Tests continue on error to allow viewing all test results even if some fail.
@@ -85,21 +85,19 @@ The Cove iOS app uses GitHub Actions for continuous integration and deployment f
 **Steps:**
 1. Checkout code with full git history
 2. Set up Ruby 4.0.1 with bundler cache
-3. Cache CocoaPods dependencies
-4. Configure git for version commits
-5. Import code signing certificates
-6. Download provisioning profiles
-7. Set up App Store Connect API key
-8. **Run `fastlane beta` lane** which:
-   - Installs CocoaPods dependencies
+3. Configure git for version commits
+4. Import code signing certificates
+5. Download provisioning profiles
+6. Set up App Store Connect API key
+7. **Run `fastlane beta` lane** which:
    - Auto-increments build number (syncs with TestFlight)
-   - Builds and archives the app
+   - Builds and archives the app (SPM packages resolved by xcodebuild)
    - Uploads to TestFlight
    - Commits and pushes version bump
-9. Get version and build info from Info.plist
-10. Check for duplicate release tags
-11. Create GitHub Release with prerelease flag
-12. Upload build artifacts on failure
+8. Get version and build info from Info.plist
+9. Check for duplicate release tags
+10. Create GitHub Release with prerelease flag
+11. Upload build artifacts on failure
 
 **Versioning:**
 - `CFBundleVersion` (Build Number): **Auto-incremented** (1, 2, 3, 4...)
@@ -117,19 +115,18 @@ The Cove iOS app uses GitHub Actions for continuous integration and deployment f
 **Steps:**
 1. Checkout code with full git history
 2. Set up Ruby 4.0.1 with bundler cache
-3. Cache CocoaPods dependencies
-4. Configure git for version commits
-5. Import code signing certificates
-6. Download provisioning profiles
-7. Set up App Store Connect API key
-8. **Run `fastlane release version:X.Y.Z` lane** which:
+3. Configure git for version commits
+4. Import code signing certificates
+5. Download provisioning profiles
+6. Set up App Store Connect API key
+7. **Run `fastlane release version:X.Y.Z` lane** which:
    - Updates marketing version to specified version
    - Auto-increments build number (syncs with TestFlight)
-   - Builds and archives the app
+   - Builds and archives the app (SPM packages resolved by xcodebuild)
    - Submits to App Store Connect
    - Commits and pushes version bump
-9. Update GitHub release notes with build information (or create new release)
-10. Upload build artifacts on failure
+8. Update GitHub release notes with build information (or create new release)
+9. Upload build artifacts on failure
 
 **Versioning:**
 - `CFBundleShortVersionString`: **Derived from legacy tag parsing logic** (non-functional with manual trigger)
@@ -243,9 +240,6 @@ base64 -i YourProfile.mobileprovision -o profileb64.txt
 # Install Ruby dependencies
 bundle install
 
-# Install CocoaPods
-pod install
-
 # Run Fastlane lanes locally
 bundle exec fastlane build    # Build for testing
 bundle exec fastlane test     # Run tests
@@ -253,11 +247,13 @@ bundle exec fastlane beta     # Deploy to TestFlight
 bundle exec fastlane release  # Deploy to App Store
 ```
 
+SPM packages are resolved automatically by xcodebuild — no separate dependency install step is needed.
+
 ## Tools Used
 
 - **GitHub Actions**: CI/CD orchestration
 - **Fastlane**: iOS automation (building, signing, deploying)
-- **CocoaPods**: Dependency management (~1.15)
+- **Swift Package Manager**: Dependency management (built into Xcode)
 - **xcodebuild**: Building and archiving iOS apps
 - **TestFlight**: Beta testing platform
 - **App Store Connect**: App distribution and management
@@ -275,7 +271,7 @@ bundle exec fastlane build
 Using xcodebuild directly:
 ```bash
 xcodebuild build \
-  -workspace Cove.xcworkspace \
+  -project Cove.xcodeproj \
   -scheme Cove \
   -sdk iphonesimulator
 ```
@@ -289,7 +285,7 @@ bundle exec fastlane test
 Using xcodebuild directly:
 ```bash
 xcodebuild test \
-  -workspace Cove.xcworkspace \
+  -project Cove.xcodeproj \
   -scheme Cove \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
 ```
@@ -322,10 +318,10 @@ bundle exec fastlane release version:1.1.0
 - The auto-increment script should prevent this
 - If it occurs, manually increment the build number
 
-### CocoaPods Installation Fails
-- Clear CocoaPods cache: `pod cache clean --all`
-- Update CocoaPods: `gem install cocoapods`
-- Delete `Podfile.lock` and `Pods` directory, then run `pod install`
+### SPM Package Resolution Fails
+- In Xcode: **File → Packages → Resolve Package Versions**
+- If that fails: **File → Packages → Reset Package Caches** (re-downloads all packages)
+- On CI: clearing `~/Library/Caches/org.swift.swiftpm` and `DerivedData` forces a full re-resolution
 
 ## Best Practices
 
@@ -344,4 +340,4 @@ bundle exec fastlane release version:1.1.0
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 - [Apple Developer Portal](https://developer.apple.com/)
 - [App Store Connect](https://appstoreconnect.apple.com/)
-- [CocoaPods](https://cocoapods.org/)
+- [Swift Package Manager](https://www.swift.org/documentation/package-manager/)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -5,7 +5,6 @@ Get the Cove iOS app building and running on your local machine.
 ## Prerequisites
 
 - **Xcode 16+** (required for iOS 18 SDK)
-- **CocoaPods** — `sudo gem install cocoapods`
 - **Ruby + Bundler** — for Fastlane (optional, only needed for CI/CD lanes)
 
 ## Steps
@@ -17,17 +16,13 @@ git clone https://github.com/danicajiao/cove-ios.git
 cd cove-ios
 ```
 
-### 2. Install dependencies
+### 2. Open the project
 
 ```bash
-pod install
+open Cove.xcodeproj
 ```
 
-Open the project using the **`.xcworkspace`** file, not `.xcodeproj`:
-
-```bash
-open Cove.xcworkspace
-```
+Dependencies are managed via Swift Package Manager. Xcode will resolve and download all packages automatically on first open.
 
 ### 3. Add `GoogleService-Info.plist`
 
@@ -54,8 +49,8 @@ Select a simulator or connected device in Xcode and press **⌘R**.
 
 ## Troubleshooting
 
-### `pod install` fails
-→ Ensure CocoaPods is up to date: `sudo gem install cocoapods`
+### SPM packages fail to resolve
+→ In Xcode, go to **File → Packages → Resolve Package Versions**. If that doesn't help, try **File → Packages → Reset Package Caches**.
 
 ### Build fails with Firebase errors
 → Verify `GoogleService-Info.plist` is present at the correct path and added to the Xcode target
@@ -65,4 +60,4 @@ Select a simulator or connected device in Xcode and press **⌘R**.
 
 ---
 
-**Last Updated**: March 2026
+**Last Updated**: May 2026


### PR DESCRIPTION
## Summary
- Removes all CocoaPods references from README, QUICK_START, and CI_CD_WORKFLOWS
- Updates setup steps: `pod install` → SPM auto-resolves in Xcode
- Updates `open Cove.xcworkspace` → `open Cove.xcodeproj`
- Replaces `-workspace` with `-project` in all xcodebuild examples
- Replaces CocoaPods troubleshooting entries with SPM equivalents
- Updates tools list and references

## Test plan
- [x] Docs read correctly end-to-end for a fresh developer setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)