### PR TITLE
Refactor auth navigation flow to remove path from AppState (#156)

### DIFF
--- a/Cove/Enums/AuthPath.swift
+++ b/Cove/Enums/AuthPath.swift
@@ -1,0 +1,9 @@
+//
+//  AuthPath.swift
+//  Cove
+//
+
+enum AuthPath: Hashable {
+    case login
+    case signup
+}

--- a/Cove/Models/AppState.swift
+++ b/Cove/Models/AppState.swift
@@ -33,7 +33,6 @@ enum AuthMethod: String {
 }
 
 class AppState: ObservableObject {
-    @Published var path: [Path] = []
     @Published var authState: AuthState = .loggedOut
     var authMethod: AuthMethod?
 
@@ -45,7 +44,6 @@ class AppState: ObservableObject {
                 DispatchQueue.main.async {
                     self.authState = .loggedIn
                     self.authMethod = .email
-                    self.path.removeAll()
                 }
                 onSuccess()
             }
@@ -63,7 +61,6 @@ class AppState: ObservableObject {
                 DispatchQueue.main.async {
                     strongSelf.authState = .loggedIn
                     strongSelf.authMethod = .email
-                    strongSelf.path.removeAll()
                 }
                 onSuccess()
             }
@@ -232,7 +229,6 @@ class AppState: ObservableObject {
                 DispatchQueue.main.async {
                     self.authMethod = .google
                     self.authState = .loggedIn
-                    self.path.removeAll()
                 }
             }
         }
@@ -264,7 +260,6 @@ class AppState: ObservableObject {
                 DispatchQueue.main.async {
                     self.authMethod = .facebook
                     self.authState = .loggedIn
-                    self.path.removeAll()
                 }
             }
         }
@@ -287,7 +282,6 @@ class AppState: ObservableObject {
                 DispatchQueue.main.async {
                     self.authState = .loggedOut
                     self.authMethod = nil
-                    self.path.removeAll()
                 }
             } catch let signOutError as NSError {
                 print("Error signing out: %@", signOutError)
@@ -300,7 +294,6 @@ class AppState: ObservableObject {
                 DispatchQueue.main.async {
                     self.authState = .loggedOut
                     self.authMethod = nil
-                    self.path.removeAll()
                 }
             } catch let signOutError as NSError {
                 print("Error signing out: %@", signOutError)
@@ -312,7 +305,6 @@ class AppState: ObservableObject {
                 DispatchQueue.main.async {
                     self.authState = .loggedOut
                     self.authMethod = nil
-                    self.path.removeAll()
                 }
             } catch let signOutError as NSError {
                 print("Error signing out: %@", signOutError)

--- a/Cove/Supporting Files/CoveApp.swift
+++ b/Cove/Supporting Files/CoveApp.swift
@@ -64,14 +64,10 @@ struct CoveApp: App {
                         .animation(.default, value: networkMonitor.isConnected)
                         .navigationDestination(for: Path.self) { path in
                             switch path {
-                            case .welcome:
-                                WelcomeView()
                             case .login:
                                 LoginView()
                             case .signup:
                                 SignupView()
-                            case .home:
-                                HomeView()
                             default:
                                 EmptyView()
                             }

--- a/Cove/Supporting Files/CoveApp.swift
+++ b/Cove/Supporting Files/CoveApp.swift
@@ -38,7 +38,7 @@ struct CoveApp: App {
     @StateObject var favoritesStore = FavoritesStore()
     @StateObject private var networkMonitor = NetworkMonitor()
 
-    @State var text: String = ""
+    @State private var authPath: [AuthPath] = []
 
     init() {
         print("init run")
@@ -51,29 +51,33 @@ struct CoveApp: App {
                     MainView()
                         .environmentObject(bag)
                 } else {
-                    NavigationStack(path: $appState.path) {
+                    NavigationStack(path: $authPath) {
                         ZStack {
                             if networkMonitor.isConnected {
-                                WelcomeView()
-                                    .transition(.opacity)
+                                WelcomeView(
+                                    onNavigateToLogin: { authPath.append(.login) },
+                                    onNavigateToSignup: { authPath.append(.signup) }
+                                )
+                                .transition(.opacity)
                             } else {
                                 SplashView()
                                     .transition(.opacity)
                             }
                         }
                         .animation(.default, value: networkMonitor.isConnected)
-                        .navigationDestination(for: Path.self) { path in
+                        .navigationDestination(for: AuthPath.self) { path in
                             switch path {
                             case .login:
-                                LoginView()
+                                LoginView(onNavigateToSignup: { authPath.append(.signup) })
                             case .signup:
-                                SignupView()
-                            default:
-                                EmptyView()
+                                SignupView(onNavigateToLogin: { authPath.append(.login) })
                             }
                         }
                     }
                 }
+            }
+            .onChange(of: appState.authState) { _, _ in
+                authPath = []
             }
             .environmentObject(appState)
             .environmentObject(favoritesStore)

--- a/Cove/Views/LoginView.swift
+++ b/Cove/Views/LoginView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct LoginView: View {
     @EnvironmentObject private var appState: AppState
 
+    var onNavigateToSignup: () -> Void
+
     @State private var presentAlert = false
     @State private var errorMessage: String?
 
@@ -130,7 +132,7 @@ struct LoginView: View {
                         .font(.custom("Lato-Regular", size: 14))
                         .foregroundStyle(Color.Colors.Text.tertiary)
                     Button {
-                        appState.path.append(.signup)
+                        onNavigateToSignup()
                     } label: {
                         Text("Sign up")
                             .font(.custom("Lato-Regular", size: 14))
@@ -148,9 +150,6 @@ struct LoginView: View {
                     .padding(Spacing.xl)
             }
             .toolbar(.hidden, for: .navigationBar)
-            .onAppear {
-                print(appState.path)
-            }
             .onDisappear {
                 email = ""
                 password = ""
@@ -168,7 +167,7 @@ struct LoginView: View {
 struct LoginView_Previews: PreviewProvider {
     static let appState = AppState()
     static var previews: some View {
-        LoginView()
+        LoginView(onNavigateToSignup: {})
             .environmentObject(appState)
     }
 }

--- a/Cove/Views/MainView.swift
+++ b/Cove/Views/MainView.swift
@@ -80,7 +80,6 @@ struct MainView: View {
         // .opacity(opacity)
         .background(Color.Colors.Backgrounds.primary)
         .onAppear {
-            print(appState.path)
             // withAnimation(.easeIn(duration: 1)) {
             //     opacity = 1
             // }

--- a/Cove/Views/ProductDetailView.swift
+++ b/Cove/Views/ProductDetailView.swift
@@ -85,11 +85,6 @@ struct ProductDetailView: View {
             }
         }
         .navigationBarHidden(true)
-        .onAppear {
-            #if DEBUG
-                print(appState.path)
-            #endif
-        }
     }
 }
 

--- a/Cove/Views/ProfileView.swift
+++ b/Cove/Views/ProfileView.swift
@@ -48,7 +48,6 @@ struct ProfileView: View {
         .confirmationDialog("Confirm Log Out", isPresented: $presentAlert) {
             Button("Log out", role: .destructive) {
                 appState.logOut()
-                appState.path.removeAll()
             }
             Button("Cancel", role: .cancel) {}
         } message: {

--- a/Cove/Views/SignupView.swift
+++ b/Cove/Views/SignupView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct SignupView: View {
     @EnvironmentObject private var appState: AppState
 
+    var onNavigateToLogin: () -> Void
+
     @State private var presentAlert = false
     @State private var errorMessage: String?
 
@@ -131,7 +133,7 @@ struct SignupView: View {
                         .font(.custom("Lato-Regular", size: 14))
                         .foregroundStyle(Color.Colors.Text.tertiary)
                     Button {
-                        appState.path.append(.login)
+                        onNavigateToLogin()
                     } label: {
                         Text("Log in")
                             .font(.custom("Lato-Regular", size: 14))
@@ -150,9 +152,6 @@ struct SignupView: View {
                     .padding(Spacing.xl)
             }
             .toolbar(.hidden, for: .navigationBar)
-            .onAppear {
-                print(appState.path)
-            }
             .onDisappear {
                 email = ""
                 password = ""
@@ -170,7 +169,7 @@ struct SignupView: View {
 struct SignupView_Previews: PreviewProvider {
     static let appState = AppState()
     static var previews: some View {
-        SignupView()
+        SignupView(onNavigateToLogin: {})
             .environmentObject(appState)
     }
 }

--- a/Cove/Views/WelcomeView.swift
+++ b/Cove/Views/WelcomeView.swift
@@ -10,7 +10,9 @@ import RiveRuntime
 import SwiftUI
 
 struct WelcomeView: View {
-    @EnvironmentObject private var appState: AppState
+    var onNavigateToLogin: () -> Void
+    var onNavigateToSignup: () -> Void
+
     var riveViewModel = RiveViewModel(
         fileName: "hero",
         alignment: .topCenter
@@ -33,14 +35,14 @@ struct WelcomeView: View {
                     .foregroundStyle(Color.Colors.Text.primary)
 
                 Button {
-                    appState.path.append(.signup)
+                    onNavigateToSignup()
                 } label: {
                     Text("Join for free")
                 }
                 .buttonStyle(PrimaryButton())
 
                 Button {
-                    appState.path.append(.login)
+                    onNavigateToLogin()
                 } label: {
                     Text("Login")
                 }
@@ -50,17 +52,11 @@ struct WelcomeView: View {
         }
         .ignoresSafeArea(edges: .top)
         .background(Color.Colors.Backgrounds.primary)
-        .onAppear {
-            print(appState.path)
-        }
     }
 }
 
 struct WelcomeView_Previews: PreviewProvider {
-    static let appState = AppState()
-
     static var previews: some View {
-        WelcomeView()
-            .environmentObject(appState)
+        WelcomeView(onNavigateToLogin: {}, onNavigateToSignup: {})
     }
 }


### PR DESCRIPTION
## Summary

Moves auth navigation state out of `AppState` into local state in `CoveApp`, leaving `AppState` as a pure domain model. Fixes a latent bug where stale navigation state could cause the wrong screen to appear after logout.

- Removes `@Published var path: [Path]` from `AppState` and all `path.removeAll()` navigation side-effects from auth methods
- Introduces `AuthPath` enum (`.login`, `.signup`) for auth-stack navigation
- Wires `NavigationStack` to `@State private var authPath` in `CoveApp`
- Resets `authPath` on logout via `.onChange(of: appState.authState)`
- Refactors `WelcomeView`, `LoginView`, and `SignupView` to accept navigation closures instead of reaching into `AppState`

## Sub-issues
- #157 — Remove navigation state from AppState
- #158 — Wire auth NavigationStack to local state in CoveApp

Closes #156