### PR TITLE
Upgrade CI to Xcode 26.3 and remove objectVersion workaround

### DIFF
--- a/.github/workflows/cd-appstore.yml
+++ b/.github/workflows/cd-appstore.yml
@@ -7,6 +7,8 @@ jobs:
   release-appstore:
     name: Build and Release to App Store
     runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cd-testflight.yml
+++ b/.github/workflows/cd-testflight.yml
@@ -12,6 +12,8 @@ jobs:
   deploy-testflight:
     name: Build and Deploy to TestFlight
     runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -16,6 +16,8 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,6 +7,8 @@ jobs:
   lint-and-validate:
     name: Lint & Validate
     runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
 
     steps:
       - name: Checkout code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 Cove is an iOS app built with SwiftUI following MVVM architecture. It uses Firebase (Auth, Firestore, Storage) for backend, Swift Package Manager for dependencies, and targets iOS 18+.
 
+**Required Xcode version: 26.3** — the project uses `objectVersion = 100` which requires Xcode 26.3+. CI explicitly selects Xcode 26.3 via `DEVELOPER_DIR=/Applications/Xcode_26.3.app/Contents/Developer`. Use Xcode 26.3 locally to stay in sync with CI.
+
 See `docs/` for architecture details: `APP_ARCHITECTURE.md`, `QUICK_START.md`, `CI_CD_WORKFLOWS.md`.
 
 ---

--- a/Cove.xcodeproj/project.pbxproj
+++ b/Cove.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 100;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -46,6 +46,7 @@
 /* Begin PBXFrameworksBuildPhase section */
 		D02B2FAF27BD7E61004732CB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				D00DB72D2FAB015100D56700 /* FirebaseCore in Frameworks */,
 				D00DB7342FAB02D000D56700 /* FacebookCore in Frameworks */,
@@ -57,6 +58,7 @@
 				D00DB72F2FAB015100D56700 /* FirebaseFirestore in Frameworks */,
 				D00DB7392FAB034900D56700 /* GoogleSignIn in Frameworks */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -91,6 +93,8 @@
 				A2C4E6F8B0D2E4F6A8C0E2F4 /* SwiftLint */,
 			);
 			buildRules = (
+			);
+			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
 				D0DA904D2D697BFE0079DDEB /* Cove */,
@@ -140,7 +144,6 @@
 				D00DB7372FAB034900D56700 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				D00DB73C2FAB03FD00D56700 /* XCRemoteSwiftPackageReference "rive-ios" */,
 			);
-			preferredProjectObjectVersion = 77;
 			productRefGroup = D02B2FB327BD7E61004732CB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -153,8 +156,10 @@
 /* Begin PBXResourcesBuildPhase section */
 		D02B2FB027BD7E61004732CB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
@@ -162,7 +167,15 @@
 		A2C4E6F8B0D2E4F6A8C0E2F4 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
 			name = SwiftLint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ -f /opt/homebrew/bin/swiftlint ]; then\n  /opt/homebrew/bin/swiftlint\nelif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 			showEnvVarsInLog = 0;
@@ -170,7 +183,15 @@
 		B4D6F8A0C2E4F6A8B0D2E4F6 /* SwiftFormat */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
 			name = SwiftFormat;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ -f /opt/homebrew/bin/swiftformat ]; then\n  /opt/homebrew/bin/swiftformat .\nelif which swiftformat > /dev/null; then\n  swiftformat .\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
 			showEnvVarsInLog = 0;
@@ -180,13 +201,15 @@
 /* Begin PBXSourcesBuildPhase section */
 		D02B2FAE27BD7E61004732CB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		D02B2FBE27BD7E62004732CB /* Debug configuration for PBXProject "Cove" */ = {
+		D02B2FBE27BD7E62004732CB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -253,7 +276,7 @@
 			};
 			name = Debug;
 		};
-		D02B2FBF27BD7E62004732CB /* Release configuration for PBXProject "Cove" */ = {
+		D02B2FBF27BD7E62004732CB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -314,7 +337,7 @@
 			};
 			name = Release;
 		};
-		D02B2FC127BD7E62004732CB /* Debug configuration for PBXNativeTarget "Cove" */ = {
+		D02B2FC127BD7E62004732CB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = Cove;
@@ -345,7 +368,7 @@
 			};
 			name = Debug;
 		};
-		D02B2FC227BD7E62004732CB /* Release configuration for PBXNativeTarget "Cove" */ = {
+		D02B2FC227BD7E62004732CB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = Cove;
@@ -382,17 +405,19 @@
 		D02B2FAD27BD7E61004732CB /* Build configuration list for PBXProject "Cove" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D02B2FBE27BD7E62004732CB /* Debug configuration for PBXProject "Cove" */,
-				D02B2FBF27BD7E62004732CB /* Release configuration for PBXProject "Cove" */,
+				D02B2FBE27BD7E62004732CB /* Debug */,
+				D02B2FBF27BD7E62004732CB /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		D02B2FC027BD7E62004732CB /* Build configuration list for PBXNativeTarget "Cove" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D02B2FC127BD7E62004732CB /* Debug configuration for PBXNativeTarget "Cove" */,
-				D02B2FC227BD7E62004732CB /* Release configuration for PBXNativeTarget "Cove" */,
+				D02B2FC127BD7E62004732CB /* Debug */,
+				D02B2FC227BD7E62004732CB /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */


### PR DESCRIPTION
## Summary

- Adds `DEVELOPER_DIR=/Applications/Xcode_26.3.app/Contents/Developer` to all four CI/CD workflows so the `macos-26` runner uses Xcode 26.3 instead of the default 26.2
- Restores `objectVersion = 100` in `project.pbxproj` (the format Xcode 26.3 naturally writes), removing the manual `77` downgrade from #199
- Removes `preferredProjectObjectVersion = 77` which was pinning the UI "Project Format" to "Xcode 16.0" and would have caused Xcode to keep downgrading the format on every save
- Includes the Xcode 26.3 format normalization Xcode applied on re-save (`buildActionMask`, `runOnlyForDeploymentPostprocessing`, `defaultConfigurationIsVisible`, simplified config comment names)
- Notes the required Xcode version in `CLAUDE.md`

## Test plan

- [x] CI "Lint & Validate" passes on this PR
- [x] Project opens in Xcode 26.3 locally and shows "Xcode 26.3" in the Project Format dropdown
- [x] Saving the project locally no longer flips `objectVersion` back to `77`

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)