### PR TITLE
Fix CI Xcode version to 26.4.1 (objectVersion 100 requires 26.4+)

### DIFF
--- a/.github/workflows/cd-appstore.yml
+++ b/.github/workflows/cd-appstore.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build and Release to App Store
     runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.4.1.app/Contents/Developer
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cd-testflight.yml
+++ b/.github/workflows/cd-testflight.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build and Deploy to TestFlight
     runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.4.1.app/Contents/Developer
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build and Test
     runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.4.1.app/Contents/Developer
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,7 +8,7 @@ jobs:
     name: Lint & Validate
     runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.4.1.app/Contents/Developer
 
     steps:
       - name: Checkout code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Cove is an iOS app built with SwiftUI following MVVM architecture. It uses Firebase (Auth, Firestore, Storage) for backend, Swift Package Manager for dependencies, and targets iOS 18+.
 
-**Required Xcode version: 26.3** — the project uses `objectVersion = 100` which requires Xcode 26.3+. CI explicitly selects Xcode 26.3 via `DEVELOPER_DIR=/Applications/Xcode_26.3.app/Contents/Developer`. Use Xcode 26.3 locally to stay in sync with CI.
+**Required Xcode version: 26.4+** — the project uses `objectVersion = 100` which requires Xcode 26.4+. CI explicitly selects Xcode 26.4.1 via `DEVELOPER_DIR=/Applications/Xcode_26.4.1.app/Contents/Developer`. Use Xcode 26.4 or later locally to stay in sync with CI.
 
 See `docs/` for architecture details: `APP_ARCHITECTURE.md`, `QUICK_START.md`, `CI_CD_WORKFLOWS.md`.
 


### PR DESCRIPTION
## Summary

Follow-up to #205. CI failed because `objectVersion = 100` is not Xcode 26.3 format — it's actually Xcode 26.4 format (confirmed by `LastUpgradeCheck = 2640` in the project file). Xcode 26.3 on the runner rejected it as a "future format."

- Updates `DEVELOPER_DIR` from `Xcode_26.3.app` → `Xcode_26.4.1.app` in all four workflows
- Corrects the Xcode version note in `CLAUDE.md` to 26.4+

## Test plan

- [x] CI - Main passes with Xcode 26.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)