### PR TITLE
Update required Xcode version to 26.4+ in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Cove is an iOS app built with SwiftUI following MVVM architecture. It uses Firebase (Auth, Firestore, Storage) for backend, Swift Package Manager for dependencies, and targets iOS 18+.
+Cove is an iOS app built with SwiftUI following MVVM architecture. It uses Firebase (Auth, Firestore, Storage) for backend, Swift Package Manager for dependencies, and targets iOS 26+.
 
 **Required Xcode version: 26.4+** — the project uses `objectVersion = 100` which requires Xcode 26.4+. CI explicitly selects Xcode 26.4.1 via `DEVELOPER_DIR=/Applications/Xcode_26.4.1.app/Contents/Developer`. Use Xcode 26.4 or later locally to stay in sync with CI.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The project also serves as a testbed for agentic development: using AI agents to
 
 | Layer | Technology |
 |---|---|
-| Platform | iOS 18+ |
+| Platform | iOS 26+ |
 | Language | Swift / SwiftUI |
 | Architecture | MVVM |
 | Backend | Firebase (Auth, Firestore, Cloud Storage) |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The project also serves as a testbed for agentic development: using AI agents to
 
 ### Prerequisites
 
-- **Xcode 26.4+** (required for iOS 18 SDK and objectVersion 100 project format)
+- **Xcode 26.4+** (required for iOS 26 SDK and objectVersion 100 project format)
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Cove/
 ├── Components/         # Reusable UI components (ProductCardView, LikeButton, etc.)
 ├── Styles/             # Custom button styles and view modifiers
 ├── Enums/              # Shared enum types (ProductTypes)
+├── Constants/          # Design token constants (Spacing.swift, Radius.swift)
 └── Resources/          # Assets, fonts (Gazpacho, Lato), Rive animations
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The project also serves as a testbed for agentic development: using AI agents to
 
 ### Prerequisites
 
-- **Xcode 16+** (required for iOS 18 SDK)
+- **Xcode 26.4+** (required for iOS 18 SDK and objectVersion 100 project format)
 
 ### Setup
 

--- a/docs/CI_CD_WORKFLOWS.md
+++ b/docs/CI_CD_WORKFLOWS.md
@@ -38,7 +38,7 @@ The Cove iOS app uses GitHub Actions for continuous integration and deployment f
 
 ### 1. CI - Pull Request (`ci-pr.yml`)
 
-**Trigger:** Pull requests to `main` branch (only when Cove/** or workflow file changes)
+**Trigger:** All pull requests (no path filter — runs on every PR)
 
 **Purpose:** Ensure code quality before merging
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -4,7 +4,7 @@ Get the Cove iOS app building and running on your local machine.
 
 ## Prerequisites
 
-- **Xcode 16+** (required for iOS 18 SDK)
+- **Xcode 26.4+** (required for iOS 18 SDK and objectVersion 100 project format)
 - **Ruby + Bundler** — for Fastlane (optional, only needed for CI/CD lanes)
 
 ## Steps

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -43,7 +43,7 @@ Select a simulator or connected device in Xcode and press **⌘R**.
 ## Notes
 
 - **Bundle ID:** `com.danicajiao.cove`
-- **Minimum deployment target:** iOS 18.0
+- **Minimum deployment target:** iOS 26.0
 - Google Sign-In and Facebook Login are configured via `Info.plist` — no additional setup required beyond the `GoogleService-Info.plist`
 - For CI/CD setup, see [CI/CD Workflows Documentation](CI_CD_WORKFLOWS.md)
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -4,7 +4,7 @@ Get the Cove iOS app building and running on your local machine.
 
 ## Prerequisites
 
-- **Xcode 26.4+** (required for iOS 18 SDK and objectVersion 100 project format)
+- **Xcode 26.4+** (required for iOS 26 SDK and objectVersion 100 project format)
 - **Ruby + Bundler** — for Fastlane (optional, only needed for CI/CD lanes)
 
 ## Steps


### PR DESCRIPTION
## Summary

- Updates `README.md` and `docs/QUICK_START.md` to reflect the correct minimum Xcode version (26.4+) following the objectVersion 100 project format upgrade in #205/#206

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)