### PR TITLE
Rewrite CATEGORY_AND_PRODUCT_ARCHITECTURE.md for Postgres

### DIFF
--- a/docs/CATEGORY_AND_PRODUCT_ARCHITECTURE.md
+++ b/docs/CATEGORY_AND_PRODUCT_ARCHITECTURE.md
@@ -1,284 +1,496 @@
 # Category and Product Architecture
 
-> **Note:** This is a planned architecture, not the current implementation. The app currently uses a flat category structure with hardcoded `categoryId` values. This document describes the target design for when the category system is expanded.
+> **Status:** Planned design. The current app uses a flat, hardcoded category set. This document describes the post-migration model in Postgres — built alongside `cove-product` in Phase 3.
 
 ## Overview
 
-This document outlines the recommended architecture for Cove's category hierarchy and product filtering system, specifically addressing multi-level categories and gender-based navigation.
+Cove's catalog has two related modeling problems that pull in different directions:
+
+1. **Categories** need to nest arbitrarily deep (Produce → Vegetables → Root Vegetables) and support fast "give me everything in this subtree" queries. The right Postgres feature for this is `ltree`.
+2. **Products** vary wildly in shape (a jar of honey has different attributes than a hand-thrown ceramic mug). The right Postgres feature for this is JSONB for the varying parts, normalized columns for the universal ones.
+
+This doc covers both, plus the third related question: how to model SKU-level variations (sizes, weights, colors) without forcing every variation to be its own product.
+
+For the overall service layout and database topology, see [Marketplace Architecture](MARKETPLACE_ARCHITECTURE.md). For Postgres mechanics (operators, indexes, JSONB syntax), see [Postgres Primer](POSTGRES_PRIMER.md).
 
 ---
 
-## Category Structure
+## Category hierarchy
 
-### Hybrid Approach: Parent Reference + Materialized Path
+### Decision: `ltree`
 
-This combines the flexibility of parent references with the query power of materialized paths.
+The `categories` table uses Postgres's `ltree` extension to store the path from root to leaf in a single column:
 
-```javascript
-categories/{categoryId}
-  - id: "shirts-tees"                    // Unique identifier
-  - name: "Shirts & Tees"                // Display name
-  - slug: "shirts-tees"                  // URL-friendly
-  - parentId: "clothing-shoes"           // Reference to parent category
-  - ancestors: ["fashion-beauty", "clothing-shoes"]  // All ancestor IDs
-  - path: "/fashion-beauty/clothing-shoes/shirts-tees"  // Full path for URLs
-  - level: 2                             // Depth in hierarchy (0 = top level)
-  - order: 1                             // Sort order within parent
-  - imageURL: "..."                      // Category image
-  - isActive: true                       // Visibility toggle
+```sql
+CREATE EXTENSION IF NOT EXISTS ltree;
+
+CREATE TABLE product.categories (
+    id   uuid  PRIMARY KEY DEFAULT gen_random_uuid(),
+    name text  NOT NULL,
+    path ltree NOT NULL UNIQUE                       -- e.g. 'produce.dairy.cheese'
+);
+
+CREATE INDEX ON product.categories USING GIST  (path);
+CREATE INDEX ON product.categories USING BTREE (path);
 ```
 
-### Example Hierarchy
+Each category's `path` is a dot-separated chain of labels representing its position in the tree. Labels must be `[A-Za-z0-9_]+` (no spaces, no hyphens), so display names like "Cheese & Dairy" get mapped to `cheese_and_dairy` for the path while the user-facing label lives in `name`.
+
+### Why not denormalized ancestor arrays?
+
+The Firestore version of this doc used a denormalized approach: a `parent_id` reference, an `ancestors` array, a `path` string, and a `level` integer — all updated together every time the tree changed.
+
+| Aspect | `ltree` | Ancestor arrays |
+|---|---|---|
+| "All descendants of X" | `WHERE path <@ 'produce'` (indexed) | `WHERE 'produce' = ANY(ancestors)` (indexed if GIN) |
+| "Direct children of X" | `WHERE path ~ 'produce.*{1}'` | `WHERE parent_id = X` |
+| "Breadcrumb path to X" | `WHERE path @> X.path ORDER BY nlevel(path)` | Fetch each ancestor by ID |
+| Rename / move a node | Update one row's `path`, descendants update via trigger or manual cascade | Update every descendant's `ancestors` array |
+| Add a new level | No data changes — just insert the row | No data changes |
+| Schema complexity | One column (`path`) | Four fields, all must stay in sync |
+| Query expressiveness | Built-in operators for every traversal | Hand-rolled for anything beyond direct children |
+
+**Why `ltree` wins for Cove:**
+- One column does the work of four; nothing to keep in sync
+- Built-in operators for every category traversal pattern we care about
+- The denormalization that ancestor arrays buy (faster "is X an ancestor of Y" queries) isn't a meaningful win at Cove's data scale
+
+**When you'd pick ancestor arrays instead:** if the chosen ORM/migration tooling didn't support `ltree` well, or if the tree was so large that the GiST index on `path` started underperforming a GIN index on an array. Neither applies here — `goose`/`golang-migrate` handle `ltree` fine and Cove's category count will be small enough that index choice is invisible.
+
+### Example hierarchy
+
+Cove's expected category tree (illustrative — actual taxonomy locked when first vendors onboard):
 
 ```
-Fashion & Beauty (level: 0, parentId: null)
-├── Clothing, Shoes, Jewelry & Watches (level: 1, parentId: "fashion-beauty")
-│   ├── Shirts & Tees (level: 2, parentId: "clothing-shoes")
-│   ├── Denim (level: 2, parentId: "clothing-shoes")
-│   └── Shoes (level: 2, parentId: "clothing-shoes")
-└── Beauty & Personal Care (level: 1, parentId: "fashion-beauty")
+food (level 0)
+├── produce
+│   ├── vegetables
+│   │   ├── root_vegetables
+│   │   └── leafy_greens
+│   └── fruits
+├── dairy
+│   ├── cheese
+│   └── yogurt
+└── pantry
+    ├── honey
+    └── preserves
+
+crafts (level 0)
+├── ceramics
+├── textiles
+└── woodwork
+
+apparel (level 0)
+├── clothing
+└── accessories
 ```
 
-### Category Queries
+`path` values are the dot-separated chains: `food.produce.vegetables.root_vegetables`, `crafts.ceramics`, etc.
 
-**Get top-level categories:**
-```swift
-db.collection("categories")
-  .whereField("parentId", isEqualTo: nil)
-  .order(by: "order")
+### Common category queries
+
+```sql
+-- Top-level categories (Home screen entry points)
+SELECT * FROM product.categories WHERE nlevel(path) = 1 ORDER BY name;
+
+-- Direct children of a category (browse one level deeper)
+SELECT * FROM product.categories WHERE path ~ 'food.produce.*{1}';
+
+-- All descendants at any depth (e.g. "show me everything under produce")
+SELECT * FROM product.categories WHERE path <@ 'food.produce';
+
+-- Breadcrumb: ancestors of a specific category, root first
+SELECT * FROM product.categories
+WHERE path @> (SELECT path FROM product.categories WHERE id = $1)
+ORDER BY nlevel(path);
+
+-- Parent of a given category (one step up)
+SELECT * FROM product.categories
+WHERE path = subpath(
+    (SELECT path FROM product.categories WHERE id = $1),
+    0,
+    nlevel((SELECT path FROM product.categories WHERE id = $1)) - 1
+);
+
+-- Move a subtree (e.g. reorganize `food.preserves` under `food.pantry`)
+UPDATE product.categories
+SET path = 'food.pantry.preserves' || subpath(path, 2)
+WHERE path <@ 'food.preserves';
 ```
 
-**Get children of a category:**
-```swift
-db.collection("categories")
-  .whereField("parentId", isEqualTo: "fashion-beauty")
-  .order(by: "order")
-```
-
-**Get all descendants of a category:**
-```swift
-db.collection("categories")
-  .whereField("ancestors", arrayContains: "fashion-beauty")
-```
-
-**Get breadcrumb path:**
-```swift
-// From ancestors array: ["fashion-beauty", "clothing-shoes"]
-// Fetch these category documents to build breadcrumb
-```
+See [Postgres Primer](POSTGRES_PRIMER.md) for the full `ltree` operator reference.
 
 ---
 
-## Gender Handling
+## Facets and filters, not categories
 
-### ✅ Recommended: Gender as Product Attribute
+The single most important modeling principle in this doc:
 
-Gender should be a **filter/facet**, not part of the category tree.
+> **Categories define *what* a product is. Attributes define *how it differs from others in the same category*.**
 
-#### Why Not Category-Based?
+When a new way to slice the catalog comes up — gender, dietary preference, certifications, season, region — it goes on the product as an attribute, **not** as a separate branch of the category tree.
 
-❌ **Bad Approach:**
+### Why this matters
+
+Consider apparel with three gender labels (Men, Women, Kids). The naive approach builds three branches:
+
 ```
 Men > Clothing > Shirts
 Women > Clothing > Shirts
 Kids > Clothing > Shirts
 ```
 
-**Problems:**
-- 3x category management overhead
-- Can't easily show "All Shirts"
-- Unisex products must be duplicated
-- Rigid, hard to expand
+That model collapses immediately when:
+- A product is unisex — must be duplicated under multiple branches
+- You want to show "All Shirts" — three subtrees to merge
+- You add a fourth gender label — every existing category needs a new branch
+- Display order, images, and translations now have to stay synced across the branches
 
-#### ✅ Good Approach: Product Attributes
+The same problem appears with dietary attributes (Vegan Cheese, Vegan Dairy, Vegan Pantry — vs Cheese, Dairy, Pantry that any product can be tagged vegan within), certifications (Organic Produce vs Produce that can be filtered to organic), seasons, regional origin, and so on.
 
-```javascript
-products/{productId}
-  - categoryId: "shirts-tees"
-  - genders: ["men"]           // Array: ["men"], ["women"], ["unisex"], or ["men", "women"]
-  - sizes: ["S", "M", "L"]
-  - colors: ["black", "white"]
-  - brand: "Nike"
+### The pattern
+
+One category tree describes *what* a product is. Attributes are columns or JSONB keys on `products` that get used as filter facets at query time.
+
+```sql
+-- Apparel example: gender as attribute
+SELECT * FROM product.products
+WHERE category_id = (SELECT id FROM product.categories WHERE path = 'apparel.clothing.shirts')
+  AND attributes @> '{"gender": "men"}';
+
+-- Cross-category facet: anything organic, regardless of what kind of product
+SELECT * FROM product.products
+WHERE attributes @> '{"certifications": ["organic"]}';
+
+-- Cross-category facet within a category subtree: organic produce
+SELECT p.*
+FROM product.products p
+JOIN product.categories c ON c.id = p.category_id
+WHERE c.path <@ 'food.produce'
+  AND p.attributes @> '{"certifications": ["organic"]}';
 ```
 
-**Benefits:**
-- Single category tree
-- Flexible filtering
-- Unisex product support
-- Easy to combine filters
+The `attributes` column is JSONB with a GIN index, so containment queries (`@>`) are fast even on large catalogs. See [Postgres Primer](POSTGRES_PRIMER.md) for the indexing details.
+
+### What goes in `attributes` vs a dedicated column
+
+A field belongs as a top-level column on `products` when:
+- Every product has it (e.g. `name`, `price_cents`, `vendor_id`)
+- It's used in JOINs or ORDER BY (e.g. `created_at`, `category_id`)
+- It needs a foreign key (e.g. `vendor_id`, `category_id`)
+
+A field belongs in `attributes` JSONB when:
+- It varies by product type (gender for apparel, flower source for honey)
+- It's used as a filter facet (containment queries) but not for JOINs
+- The set of valid keys evolves without schema migrations
 
 ---
 
-## Product Structure
+## Products
 
-### Complete Product Document
-
-```javascript
-products/{productId}
-  // Basic Info
-  - name: "Classic Cotton T-Shirt"
-  - defaultPrice: 29.99
-  - defaultImageURL: "gs://..."
-  
-  // Category
-  - categoryId: "shirts-tees"                              // Primary category (leaf node)
-  - categoryAncestors: ["fashion-beauty", "clothing", "shirts-tees"]  // For hierarchical queries
-  
-  // Attributes (Filters/Facets)
-  - genders: ["men", "women"]    // Array allows unisex
-  - sizes: ["XS", "S", "M", "L", "XL"]
-  - colors: ["black", "white", "gray"]
-  - tags: ["casual", "summer", "cotton"]
-  - brand: "Nike"
-  
-  // Additional
-  - info: { ... }                // Product-type specific info
-  - productDetailsId: "..."      // Reference to product_details
-  - createdAt: timestamp
-  - isFavorite: null             // Set client-side
+```sql
+CREATE TABLE product.products (
+    id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    vendor_id   uuid        NOT NULL REFERENCES vendor.vendors(id),
+    category_id uuid        NOT NULL REFERENCES product.categories(id),
+    name        text        NOT NULL,
+    description text,
+    price_cents integer     NOT NULL,
+    image_key   text,                                -- Garage cove-media object key
+    attributes  jsonb       NOT NULL DEFAULT '{}',   -- filterable facets (see Facets section)
+    search_vec  tsvector    GENERATED ALWAYS AS (
+        to_tsvector('english', coalesce(name, '') || ' ' || coalesce(description, ''))
+    ) STORED,
+    is_active   boolean     NOT NULL DEFAULT true,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
 ```
 
-### Product Queries
+Every product has a `price_cents` and `category_id`. Variations (different sizes, colors, weights) live in `product_variants` rather than as separate products. Type-specific extended attributes that don't make sense to filter on (ingredient lists, care instructions, brewing notes) live in `product_details`.
 
-**Men's shirts:**
-```swift
-db.collection("products")
-  .whereField("categoryId", isEqualTo: "shirts-tees")
-  .whereField("genders", arrayContains: "men")
+### Example rows
+
+```sql
+-- A jar of wildflower honey
+INSERT INTO product.products (vendor_id, category_id, name, description, price_cents, attributes) VALUES (
+    'vendor_smith_apiary_id',
+    'category_food_pantry_honey_id',
+    'Wildflower Honey',
+    'Raw, unfiltered wildflower honey from local hives.',
+    1299,
+    '{
+        "certifications": ["raw", "local"],
+        "diet": ["vegetarian"],
+        "flower_source": "wildflower"
+    }'
+);
+
+-- A men's cotton t-shirt
+INSERT INTO product.products (vendor_id, category_id, name, description, price_cents, attributes) VALUES (
+    'vendor_threadworks_id',
+    'category_apparel_clothing_shirts_id',
+    'Classic Cotton Tee',
+    'Locally screen-printed cotton t-shirt.',
+    2999,
+    '{
+        "gender": "men",
+        "brand": "Threadworks",
+        "tags": ["casual", "summer"]
+    }'
+);
 ```
 
-**Women's clothing (all categories under "clothing"):**
-```swift
-db.collection("products")
-  .whereField("categoryAncestors", arrayContains: "clothing")
-  .whereField("genders", arrayContains: "women")
-```
-
-**All shirts (no gender filter):**
-```swift
-db.collection("products")
-  .whereField("categoryId", isEqualTo: "shirts-tees")
-```
-
-**Combined filters (Women's Nike shoes under $50):**
-```swift
-db.collection("products")
-  .whereField("categoryId", isEqualTo: "shoes")
-  .whereField("genders", arrayContains: "women")
-  .whereField("brand", isEqualTo: "Nike")
-  .whereField("defaultPrice", isLessThan: 50)
-```
+The `attributes` JSONB doesn't have a fixed schema — each product type writes the keys that make sense for it. The application layer (or a future admin UI) validates which keys are valid for which category, but Postgres doesn't enforce that.
 
 ---
 
-## UI Navigation Flow
+## Product variants
 
-### Gender Entry Points
+Variants represent SKU-level differences that don't justify being separate products: the same wildflower honey in 8oz, 16oz, and 32oz jars; the same t-shirt in S/M/L and black/white.
 
-Gender-based navigation is implemented at the **UI level**, not as separate categories:
+```sql
+CREATE TABLE product.product_variants (
+    id          uuid    PRIMARY KEY DEFAULT gen_random_uuid(),
+    product_id  uuid    NOT NULL REFERENCES product.products(id) ON DELETE CASCADE,
+    sku         text    UNIQUE,
+    options     jsonb   NOT NULL,                    -- {"size": "M", "color": "black"}
+    price_cents integer,                             -- NULL means inherit products.price_cents
+    is_active   boolean NOT NULL DEFAULT true
+);
 
-```javascript
-// UI Configuration (could be in Firebase or hardcoded)
-navigationLinks: [
-  {
-    label: "Shop Women's",
-    filter: { gender: "women" },
-    featuredCategories: ["dresses", "shoes", "jewelry"]
-  },
-  {
-    label: "Shop Men's", 
-    filter: { gender: "men" },
-    featuredCategories: ["shirts", "pants", "shoes"]
-  },
-  {
-    label: "Shop Kids",
-    filter: { gender: "kids" },
-    featuredCategories: ["toys", "clothing"]
-  }
-]
+CREATE INDEX ON product.product_variants (product_id);
 ```
 
-### Example User Flow
+`options` is a JSONB object naming the dimensions for this variant. Different product types name different dimensions:
 
-1. **Home Screen** → User taps "Shop Men's" button
-2. **Gender Filter Applied:** `genders = ["men"]`
-3. **Show Categories** that have men's products (can filter categories by checking if they have products)
-4. **User Clicks** "Shirts & Tees" category
-5. **Query Products:**
-   ```swift
-   categoryId = "shirts-tees" AND 
-   genders arrayContains "men"
-   ```
-6. **Display** filtered products with additional filter options (brand, price, size, color)
+```sql
+-- Honey variants: size only
+INSERT INTO product.product_variants (product_id, sku, options, price_cents) VALUES
+    ('product_honey_id', 'HONEY-8OZ',  '{"size": "8oz"}',  799),
+    ('product_honey_id', 'HONEY-16OZ', '{"size": "16oz"}', 1299),
+    ('product_honey_id', 'HONEY-32OZ', '{"size": "32oz"}', 2299);
 
-### Breadcrumb Example
-
-```
-Home > Men's > Clothing > Shirts & Tees
+-- T-shirt variants: size × color
+INSERT INTO product.product_variants (product_id, sku, options, price_cents) VALUES
+    ('product_tee_id', 'TEE-S-BLK',  '{"size": "S", "color": "black"}', NULL),  -- NULL = inherit base price
+    ('product_tee_id', 'TEE-M-BLK',  '{"size": "M", "color": "black"}', NULL),
+    ('product_tee_id', 'TEE-S-WHT',  '{"size": "S", "color": "white"}', NULL);
 ```
 
-**Implementation:**
-- "Home" = root
-- "Men's" = gender filter (not a category)
-- "Clothing" = ancestor category
-- "Shirts & Tees" = current category
+The product itself owns the "base" price and image; variants override price when needed and (in a future enhancement) can override images. The iOS app shows the product card with the base price and lets the user pick a variant on the detail screen.
+
+### Why JSONB on `options` and not separate columns
+
+The dimensions vary by product type (size for honey, size+color for shirts, color+material for ceramics). A normalized schema would need a junction table or a wide nullable schema. JSONB stays compact and supports containment queries if needed (e.g. "all variants where size = S"):
+
+```sql
+SELECT * FROM product.product_variants WHERE options @> '{"size": "S"}';
+```
+
+If specific dimensions become highly queryable across all product types, they can be promoted to dedicated columns later.
 
 ---
 
-## Benefits of This Architecture
+## Product details (polymorphic)
 
-### ✅ Flexibility
-- Single category tree to maintain
-- Easy to add/remove/reorder categories
-- Supports unlimited hierarchy depth
+`product_details` holds the long-form, type-specific data that doesn't fit on `products` and doesn't filter cleanly. Examples:
 
-### ✅ Performance
-- Efficient queries with `ancestors` array
-- Can query entire branches
-- Minimal document reads
+- **Honey:** floral notes, harvest date, hive location, full extraction process
+- **Cheese:** milk source, aging duration, pasteurization status, rind type
+- **Apparel:** material composition, care instructions, origin country
+- **Ceramics:** clay type, glaze description, firing temperature
 
-### ✅ Scalability
-- Gender as attribute scales to any facet (age, season, style)
-- Can combine multiple filters
-- Supports unisex/multi-gender products
+### Decision: single table with JSONB
 
-### ✅ User Experience
-- Amazon-style browsing
-- Clear navigation paths
-- Flexible filtering
+```sql
+CREATE TABLE product.product_details (
+    product_id uuid  PRIMARY KEY REFERENCES product.products(id) ON DELETE CASCADE,
+    payload    jsonb NOT NULL
+);
+
+CREATE INDEX ON product.product_details USING GIN (payload);
+```
+
+One row per product, keyed by `product_id`. The `payload` column stores whatever shape that product type needs.
+
+```sql
+-- Honey details
+INSERT INTO product.product_details (product_id, payload) VALUES (
+    'product_honey_id',
+    '{
+        "harvest_date": "2026-04-15",
+        "extraction": "cold_pressed",
+        "floral_notes": "wildflower meadow",
+        "hive_location": "Smith Apiary, North Pasture"
+    }'
+);
+
+-- Cheese details
+INSERT INTO product.product_details (product_id, payload) VALUES (
+    'product_cheese_id',
+    '{
+        "milk_source": "sheep",
+        "aging_months": 6,
+        "pasteurization": "raw",
+        "rind": "natural"
+    }'
+);
+```
+
+### Why JSONB and not per-type tables (`coffee_product_details`, `apparel_product_details`)
+
+| Aspect | Single JSONB table | Per-type tables |
+|---|---|---|
+| Adding a new product type | Just write the new payload shape — no migration | New `CREATE TABLE`, new migration, new schema row |
+| Adding a field to an existing type | Just include it in new rows | `ALTER TABLE` with default |
+| Querying across types | Single query | Union or per-type queries |
+| Type-safe schema at the DB level | None — application validates | Strong column-level types |
+| Required-field enforcement | None — application validates | NOT NULL constraints |
+| Joining details into product responses | Single LEFT JOIN | LEFT JOIN per known type, or polymorphism in app code |
+| Indexing | GIN on payload — works across types | B-tree per column per table |
+
+**Why JSONB wins for Cove:**
+- Product types will evolve organically as new vendor categories come on (a new bakery brings a new "baked goods" type with proofing times and crumb descriptions). With per-type tables, every new vendor type is a migration.
+- The detail payload is read whole — there's no use case for joining honey details with cheese details. The "single query for all types" advantage isn't load-bearing.
+- The type-safety loss is fine here. Details are read-mostly display data, not validation-critical.
+- Migrations are expensive; payload evolution is free.
+
+**When you'd pick per-type tables instead:** if the detail data drove transactions (orders, inventory, payments) where missing-fields-as-NULLs would corrupt downstream logic. That's not the case for v1.
+
+### How `attributes` and `payload` differ
+
+It's reasonable to ask why both exist:
+
+| | `products.attributes` (JSONB) | `product_details.payload` (JSONB) |
+|---|---|---|
+| What it stores | Filter facets — short, structured values used in queries | Long-form display data — descriptions, dates, locations |
+| Indexed | GIN on `attributes` (containment queries) | GIN on `payload` (less heavily used) |
+| Query pattern | `WHERE attributes @> '{"gender": "men"}'` | `SELECT payload FROM product_details WHERE product_id = $1` |
+| When loaded | On every product list response | Only on product detail screens |
+
+In practice: if you might filter on it, it goes in `attributes`. If it's there to display on a detail screen, it goes in `payload`.
 
 ---
 
-## Implementation Checklist
+## Full-text search
 
-### Phase 1: Category Setup
-- [ ] Create `categories` collection with recommended fields
-- [ ] Populate hierarchy with `parentId` and `ancestors`
-- [ ] Add `level` and `order` for display
+`products.search_vec` is a generated `tsvector` column populated automatically from `name` and `description`:
 
-### Phase 2: Product Updates
-- [ ] Add `genders` array field to products
-- [ ] Add `categoryAncestors` array field
-- [ ] Update existing products with gender data
+```sql
+search_vec tsvector GENERATED ALWAYS AS (
+    to_tsvector('english', coalesce(name, '') || ' ' || coalesce(description, ''))
+) STORED;
 
-### Phase 3: UI Implementation
-- [ ] Implement gender navigation buttons
-- [ ] Create category browser with hierarchy
-- [ ] Build filtering UI
-- [ ] Add breadcrumb navigation
+CREATE INDEX ON product.products USING GIN (search_vec);
+```
 
-### Phase 4: Queries
-- [ ] Implement category hierarchy queries
-- [ ] Add gender filtering to product queries
-- [ ] Support combined filters (gender + category + price + brand)
+Search query:
+
+```sql
+SELECT id, name FROM product.products
+WHERE is_active = true
+  AND search_vec @@ websearch_to_tsquery('english', $1)
+ORDER BY ts_rank(search_vec, websearch_to_tsquery('english', $1)) DESC
+LIMIT 25;
+```
+
+`websearch_to_tsquery` is forgiving of user-typed input (handles phrases like `"raw honey"`, negations like `organic -processed`, and never throws on malformed queries). See [Postgres Primer](POSTGRES_PRIMER.md) for FTS details and ranking strategies.
+
+---
+
+## Indexes by query pattern
+
+| Query pattern | Index used |
+|---|---|
+| Browse direct children of a category | `product.categories USING GIST (path)` — handles `path ~ 'food.produce.*{1}'` |
+| Browse all products in a category subtree | `product.products (category_id) WHERE is_active = true` (partial) + GIST on category path for the subtree expansion |
+| Filter by attribute (`{"gender": "men"}`, `{"certifications": ["organic"]}`) | `product.products USING GIN (attributes)` |
+| Filter by price range | `product.products (price_cents)` |
+| Filter by vendor | `product.products (vendor_id)` |
+| Full-text search | `product.products USING GIN (search_vec)` |
+| Variant lookup by SKU | `product.product_variants (sku)` (UNIQUE constraint implies B-tree index) |
+| Variant filter by options | `product.product_variants USING GIN (options)` |
+| Product details fetch | `product.product_details (product_id)` (PRIMARY KEY) |
+
+For combined queries (e.g. "organic produce under $20"), Postgres uses bitmap index scans to AND the relevant indexes. The query planner picks which indexes to combine based on selectivity statistics — keep them fresh with `ANALYZE` after bulk loads.
+
+---
+
+## User-facing flows mapped to queries
+
+### Home screen → top-level categories
+
+```sql
+SELECT id, name FROM product.categories WHERE nlevel(path) = 1 ORDER BY name;
+```
+
+### Category browse → products in this subtree
+
+```sql
+SELECT p.id, p.name, p.price_cents, p.image_key
+FROM product.products p
+JOIN product.categories c ON c.id = p.category_id
+WHERE c.path <@ $1                     -- the selected category's path
+  AND p.is_active
+ORDER BY p.created_at DESC
+LIMIT 50;
+```
+
+### Apply filter facets
+
+```sql
+SELECT p.id, p.name, p.price_cents, p.image_key
+FROM product.products p
+JOIN product.categories c ON c.id = p.category_id
+WHERE c.path <@ $1                     -- category subtree
+  AND p.attributes @> $2               -- e.g. '{"certifications": ["organic"]}'
+  AND p.price_cents BETWEEN $3 AND $4
+  AND p.is_active
+ORDER BY p.created_at DESC;
+```
+
+### Product detail page (single round trip)
+
+```sql
+SELECT
+    p.id, p.name, p.description, p.price_cents, p.image_key, p.attributes,
+    v.id AS vendor_id, v.name AS vendor_name,
+    c.path AS category_path,
+    pd.payload AS details,
+    (
+        SELECT json_agg(json_build_object(
+            'id', pv.id, 'sku', pv.sku, 'options', pv.options,
+            'price_cents', COALESCE(pv.price_cents, p.price_cents)
+        ))
+        FROM product.product_variants pv
+        WHERE pv.product_id = p.id AND pv.is_active
+    ) AS variants
+FROM product.products p
+JOIN vendor.vendors        v  ON v.id = p.vendor_id
+JOIN product.categories    c  ON c.id = p.category_id
+LEFT JOIN product.product_details pd ON pd.product_id = p.id
+WHERE p.id = $1;
+```
+
+One query returns everything the detail screen needs.
+
+---
+
+## What's deliberately not modeled
+
+Each of these belongs in a future phase:
+
+- **Inventory and stock counts** — not in v1; no order management
+- **Reviews and ratings** — out of scope per Phase 0 epic
+- **Wish lists separate from favorites** — favorites already exist in `user.favorites`
+- **Product status workflows beyond `is_active`** — no draft/published/archived states yet
+- **Vendor-driven promotions or sale pricing** — `price_cents` is canonical; no historical pricing
+- **Multi-currency** — `price_cents` assumed USD until international scope
 
 ---
 
 ## References
 
-This architecture is based on patterns used by:
-- Amazon's category and filtering system
-- Nike's product navigation
-- E-commerce best practices for Firestore
-
-**Key Principle:** Categories define **what** the product is. Attributes (gender, size, color, brand) define **who it's for** and **variations**.
+- [Marketplace Architecture](MARKETPLACE_ARCHITECTURE.md) — service layout, database topology, where this schema lives
+- [Postgres Primer](POSTGRES_PRIMER.md) — `ltree` operators, JSONB syntax, FTS, indexes
+- [Backend Infrastructure](BACKEND_INFRASTRUCTURE.md) — cluster + deployment model


### PR DESCRIPTION
## Summary

Full Postgres rewrite of `docs/CATEGORY_AND_PRODUCT_ARCHITECTURE.md`. The category hierarchy and product modeling **principles** survive the migration intact (facets vs categories, gender-as-attribute, polymorphic details); the storage primitives change from Firestore documents to Postgres tables with JSONB.

## Modeling decisions (with tradeoffs documented)

| Decision | Picked | Why |
|---|---|---|
| Category hierarchy | `ltree` | One column does the work of four (`parent_id` + `ancestors` + `path` + `level`); built-in operators for every traversal; subtree moves are one UPDATE |
| Polymorphic product details | Single table with JSONB `payload` | New product types ship without migrations; payloads are read-whole; no transactional dependency on detail fields |

Both decisions include a side-by-side tradeoff table so the alternative is documented, not lost.

## Acceptance criteria from #221

- [x] Firestore vocabulary removed (collections, documents, subcollections, denormalization-for-reads-only)
- [x] `categories` table using `ltree` — tradeoff with ancestor arrays documented
- [x] `products` as a normalized table with FK to `categories` (and `vendor.vendors`)
- [x] `product_variants` as a normalized table (options JSONB for dimension flexibility)
- [x] Polymorphic `product_details`: single table with JSONB — tradeoff with per-type tables documented
- [x] `tsvector` column for FTS indexed with GIN
- [x] Gender-as-attribute principle preserved and generalized to all facets (certifications, dietary preferences, brand, etc.)
- [x] Indexes documented per query pattern (table at the bottom)
- [x] Cross-links to `docs/POSTGRES_PRIMER.md` and `docs/MARKETPLACE_ARCHITECTURE.md`

## Notable additions beyond the AC

- **Domain-fit examples**: switched from fashion-only examples to a mix that reflects Cove's actual catalog (food/produce/dairy/pantry, crafts, apparel as one category among many)
- **`attributes` vs `payload` distinction**: clear rule for which JSONB column a field belongs in
- **Worked SQL queries** for every user-facing flow (home screen, category browse, filter facets, product detail single-round-trip, full-text search)
- **"What's deliberately not modeled"** section listing v1 exclusions

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)