### PR TITLE
Add MEDIA_ARCHITECTURE.md and replace products.image_key with product_media

### DIFF
--- a/docs/CATEGORY_AND_PRODUCT_ARCHITECTURE.md
+++ b/docs/CATEGORY_AND_PRODUCT_ARCHITECTURE.md
@@ -196,7 +196,6 @@ CREATE TABLE product.products (
     name        text        NOT NULL,
     description text,
     price_cents integer     NOT NULL,
-    image_key   text,                                -- Garage cove-media object key
     attributes  jsonb       NOT NULL DEFAULT '{}',   -- filterable facets (see Facets section)
     search_vec  tsvector    GENERATED ALWAYS AS (
         to_tsvector('english', coalesce(name, '') || ' ' || coalesce(description, ''))
@@ -206,7 +205,7 @@ CREATE TABLE product.products (
 );
 ```
 
-Every product has a `price_cents` and `category_id`. Variations (different sizes, colors, weights) live in `product_variants` rather than as separate products. Type-specific extended attributes that don't make sense to filter on (ingredient lists, care instructions, brewing notes) live in `product_details`.
+Every product has a `price_cents` and `category_id`. Variations (different sizes, colors, weights) live in `product_variants` rather than as separate products. Type-specific extended attributes that don't make sense to filter on (ingredient lists, care instructions, brewing notes) live in `product_details`. Images live in `product_media` — exactly one `primary` image (shown in list views) and zero or more `gallery` images (detail carousel); see [Media Architecture](MEDIA_ARCHITECTURE.md) for the full storage + transformation + serving pipeline.
 
 ### Example rows
 
@@ -427,9 +426,19 @@ SELECT id, name FROM product.categories WHERE nlevel(path) = 1 ORDER BY name;
 ### Category browse → products in this subtree
 
 ```sql
-SELECT p.id, p.name, p.price_cents, p.image_key
+SELECT
+    p.id, p.name, p.price_cents,
+    m.media_key AS primary_image_key,
+    m.width  AS primary_image_width,
+    m.height AS primary_image_height
 FROM product.products p
 JOIN product.categories c ON c.id = p.category_id
+LEFT JOIN LATERAL (
+    SELECT media_key, width, height
+    FROM product.product_media
+    WHERE product_id = p.id AND role = 'primary'
+    LIMIT 1
+) m ON TRUE
 WHERE c.path <@ $1                     -- the selected category's path
   AND p.is_active
 ORDER BY p.created_at DESC
@@ -439,9 +448,19 @@ LIMIT 50;
 ### Apply filter facets
 
 ```sql
-SELECT p.id, p.name, p.price_cents, p.image_key
+SELECT
+    p.id, p.name, p.price_cents,
+    m.media_key AS primary_image_key,
+    m.width  AS primary_image_width,
+    m.height AS primary_image_height
 FROM product.products p
 JOIN product.categories c ON c.id = p.category_id
+LEFT JOIN LATERAL (
+    SELECT media_key, width, height
+    FROM product.product_media
+    WHERE product_id = p.id AND role = 'primary'
+    LIMIT 1
+) m ON TRUE
 WHERE c.path <@ $1                     -- category subtree
   AND p.attributes @> $2               -- e.g. '{"certifications": ["organic"]}'
   AND p.price_cents BETWEEN $3 AND $4
@@ -449,11 +468,13 @@ WHERE c.path <@ $1                     -- category subtree
 ORDER BY p.created_at DESC;
 ```
 
+In both queries the application layer (`cove-product`) turns each `primary_image_key` into a set of signed imgproxy variant URLs (`thumb`, `sm`, `md`) before returning the response — see [Media Architecture](MEDIA_ARCHITECTURE.md).
+
 ### Product detail page (single round trip)
 
 ```sql
 SELECT
-    p.id, p.name, p.description, p.price_cents, p.image_key, p.attributes,
+    p.id, p.name, p.description, p.price_cents, p.attributes,
     v.id AS vendor_id, v.name AS vendor_name,
     c.path AS category_path,
     pd.payload AS details,
@@ -464,7 +485,15 @@ SELECT
         ))
         FROM product.product_variants pv
         WHERE pv.product_id = p.id AND pv.is_active
-    ) AS variants
+    ) AS variants,
+    (
+        SELECT json_agg(json_build_object(
+            'media_key', pm.media_key, 'role', pm.role, 'sort_order', pm.sort_order,
+            'alt_text', pm.alt_text, 'width', pm.width, 'height', pm.height
+        ) ORDER BY pm.sort_order)
+        FROM product.product_media pm
+        WHERE pm.product_id = p.id
+    ) AS media
 FROM product.products p
 JOIN vendor.vendors        v  ON v.id = p.vendor_id
 JOIN product.categories    c  ON c.id = p.category_id
@@ -472,7 +501,7 @@ LEFT JOIN product.product_details pd ON pd.product_id = p.id
 WHERE p.id = $1;
 ```
 
-One query returns everything the detail screen needs.
+One query returns everything the detail screen needs. The `cove-product` handler post-processes the `media` array, signing the 5-variant set for each item before returning the JSON.
 
 ---
 
@@ -492,5 +521,6 @@ Each of these belongs in a future phase:
 ## References
 
 - [Marketplace Architecture](MARKETPLACE_ARCHITECTURE.md) — service layout, database topology, where this schema lives
+- [Media Architecture](MEDIA_ARCHITECTURE.md) — product image storage, transformation, serving, variant catalog, vendor upload pipeline
 - [Postgres Primer](POSTGRES_PRIMER.md) — `ltree` operators, JSONB syntax, FTS, indexes
 - [Backend Infrastructure](BACKEND_INFRASTRUCTURE.md) — cluster + deployment model

--- a/docs/MARKETPLACE_ARCHITECTURE.md
+++ b/docs/MARKETPLACE_ARCHITECTURE.md
@@ -47,11 +47,11 @@ All v1 services share one CNPG `Cluster` (`cove-db`) and one database (`cove`), 
 
 | Schema | Owning service | Tables |
 |---|---|---|
-| `product` | `cove-product` | `categories`, `products`, `product_variants`, `product_details` |
+| `product` | `cove-product` | `categories`, `products`, `product_variants`, `product_details`, `product_media` |
 | `vendor` | `cove-vendor` (future, see below) | `vendors` |
 | `user` | `cove-user` | `users`, `favorites`, `follows` |
 
-`cove-image` is stateless — it reads and writes Garage directly and stores no metadata of its own. The `image_key` column on `products` is the system of record for which image belongs to which product.
+`cove-image` is stateless — it writes uploaded images to Garage but stores no metadata of its own. The `product_media` table is the system of record for which images belong to which product, their roles (primary vs gallery), and their carousel order. The full image storage, transformation, and serving pipeline is documented in [Media Architecture](MEDIA_ARCHITECTURE.md).
 
 ### `vendor` schema: pre-positioned for cove-vendor
 
@@ -109,16 +109,25 @@ This means:
 ```sql
 -- The whole Favorites view: list of favorited products with everything
 -- the UI needs to render product cards. One query, one round trip.
+-- LATERAL JOIN pulls the primary image (see Media Architecture).
 SELECT
     p.id,
     p.name,
     p.price_cents,
-    p.image_key,
     v.name AS vendor_name,
+    m.media_key  AS primary_image_key,
+    m.width      AS primary_image_width,
+    m.height     AS primary_image_height,
     f.created_at AS favorited_at
 FROM "user".favorites f
 JOIN product.products  p ON p.id = f.product_id
 JOIN vendor.vendors    v ON v.id = p.vendor_id
+LEFT JOIN LATERAL (
+    SELECT media_key, width, height
+    FROM product.product_media
+    WHERE product_id = p.id AND role = 'primary'
+    LIMIT 1
+) m ON TRUE
 WHERE f.uid = $1
 ORDER BY f.created_at DESC;
 ```
@@ -131,9 +140,10 @@ ORDER BY f.created_at DESC;
 |---|---|---|---|
 | Vendors | `vendor` | `cove-vendor` (future) — read-only from other services in Phase 3 | Producer or business that owns one or more products. Seeded once during Phase 3 migration. |
 | Categories | `product` | `cove-product` | Hierarchical via `ltree` (e.g. `produce.dairy.cheese`). |
-| Products | `product` | `cove-product` | Catalog entries with name, description, price, image key, full-text search vector. FK to `vendor.vendors`. |
+| Products | `product` | `cove-product` | Catalog entries with name, description, price, full-text search vector. FK to `vendor.vendors`. |
 | Product variants | `product` | `cove-product` | SKU-level variations (size, color, weight). One product → many variants. |
 | Product details | `product` | `cove-product` | Polymorphic extended attributes that vary by category (e.g. `flower_source` for honey, `material` for clothing). Stored as JSONB. |
+| Product media | `product` | `cove-product` | Images attached to a product. Exactly one `primary` (used in all list views) and zero or more `gallery` (detail carousel). See [Media Architecture](MEDIA_ARCHITECTURE.md). |
 | Users | `user` | `cove-user` | Profile data. `uid` matches the Firebase Auth UID — no separate identity layer. |
 | Favorites | `user` | `cove-user` | Per-user product saves. Real FK to `product.products(id)`. |
 | Follows | `user` | `cove-user` | Per-user vendor follows. Real FK to `vendor.vendors(id)`. |
@@ -214,7 +224,6 @@ CREATE TABLE product.products (
     name        text        NOT NULL,
     description text,
     price_cents integer     NOT NULL,
-    image_key   text,                                -- Garage cove-media object key
     attributes  jsonb       NOT NULL DEFAULT '{}',   -- gender, brand, tags, etc.
     search_vec  tsvector    GENERATED ALWAYS AS (
         to_tsvector('english', coalesce(name, '') || ' ' || coalesce(description, ''))
@@ -249,6 +258,24 @@ CREATE TABLE product.product_details (
 );
 
 CREATE INDEX ON product.product_details USING GIN (payload);
+
+-- Product images. One row per uploaded image; role distinguishes the
+-- primary (shown in every list view) from gallery images (detail carousel).
+-- See docs/MEDIA_ARCHITECTURE.md for the full image storage + serving pipeline.
+CREATE TABLE product.product_media (
+    id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    product_id  uuid        NOT NULL REFERENCES product.products(id) ON DELETE CASCADE,
+    media_key   text        NOT NULL,                 -- Garage cove-media object key (content-addressed)
+    role        text        NOT NULL CHECK (role IN ('primary', 'gallery')),
+    sort_order  integer     NOT NULL DEFAULT 0,
+    alt_text    text,                                 -- accessibility / future SEO
+    width       integer     NOT NULL,                 -- source dimensions (for layout hints on the client)
+    height      integer     NOT NULL,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (product_id, role) DEFERRABLE INITIALLY DEFERRED  -- exactly one primary per product
+);
+
+CREATE INDEX ON product.product_media (product_id, sort_order);
 ```
 
 ### `user` schema
@@ -302,8 +329,8 @@ cove-gateway
    │
    ▼
 cove-product
-   │  Queries the `product` schema (products + product_variants + product_details JOIN)
-   │  Builds response payload with image URL constructed from image_key via imgproxy
+   │  Queries the `product` schema (products + product_variants + product_details + product_media JOINs)
+   │  Builds response payload with image URLs constructed via signed imgproxy URLs (see MEDIA_ARCHITECTURE.md)
    │
    ▼
 HTTP 200 → iOS app
@@ -361,6 +388,7 @@ See [Backend Infrastructure](BACKEND_INFRASTRUCTURE.md) for the cluster topology
 
 - [Backend Infrastructure](BACKEND_INFRASTRUCTURE.md) — cluster topology, deployment, phases
 - [Category & Product Architecture](CATEGORY_AND_PRODUCT_ARCHITECTURE.md) — category hierarchy, gender as attribute, product filtering details
+- [Media Architecture](MEDIA_ARCHITECTURE.md) — image storage, transformation, serving, vendor upload, signed URLs
 - [Postgres Primer](POSTGRES_PRIMER.md) — schemas, indexes, JSONB, full-text search, ltree
 - [App Architecture](APP_ARCHITECTURE.md) — iOS app structure, ViewModels, repository protocol layer
 
@@ -373,3 +401,4 @@ See [Backend Infrastructure](BACKEND_INFRASTRUCTURE.md) for the cluster topology
 - **Version 3.0** — Phase 0 implementation alignment (May 2026). Updated to reflect Garage (not MinIO) for object storage, monorepo service locations under `apps/<service>/`, added `product_variants` and `product_details` tables, removed Visit List (out of scope for v1).
 - **Version 3.1** — Database topology revision (May 2026). Switched from per-service Postgres clusters (`product-db` / `user-db`) to a single shared cluster (`cove-db`) with schemas-per-service (`product`, `user`). Cross-schema foreign keys preserve referential integrity for cross-service references like favorites and follows. Trade-off rationale documented inline.
 - **Version 3.2** — Vendor schema pre-positioned (May 2026). Split `vendors` out of the `product` schema into its own `vendor` schema in anticipation of a near-term `cove-vendor` service (vendor onboarding flow + dashboard). Phase 3 introduces the schema with read-only access from `cove-product` and `cove-user`; the future service takes ownership via a permissions flip, no data migration required.
+- **Version 3.3** — Product media split (May 2026). Replaced the single `products.image_key` column with a `product_media` child table supporting multiple images per product (one `primary` + many `gallery`), source dimensions, alt text, and carousel ordering. Full image storage/transformation/serving architecture moved to `docs/MEDIA_ARCHITECTURE.md`.

--- a/docs/MEDIA_ARCHITECTURE.md
+++ b/docs/MEDIA_ARCHITECTURE.md
@@ -1,0 +1,493 @@
+# Media Architecture
+
+> **Status:** Planned — built in Phase 2 alongside `cove-image`. v1 covers product images only; videos and documents are deferred. The bucket `cove-media` is already provisioned in Garage.
+
+## Overview
+
+Every product in Cove has at least one image, and most have a small gallery. Those images need to:
+
+- Render fast and crisp on every device size (small iPhone to 4K desktop in a future web client)
+- Survive an upload from any vendor's camera (HEIC, JPEG, PNG, oddly-rotated, with embedded GPS metadata)
+- Cache aggressively at the edge so the cluster doesn't re-do work
+- Stay safe from URL abuse without breaking how `<img>` and `AsyncImage` work
+
+This doc describes the system that delivers all of that. For the broader catalog model see [Marketplace Architecture](MARKETPLACE_ARCHITECTURE.md); for product schema specifics see [Category & Product Architecture](CATEGORY_AND_PRODUCT_ARCHITECTURE.md); for Postgres mechanics see [Postgres Primer](POSTGRES_PRIMER.md).
+
+---
+
+## The mental model
+
+Three pieces, each doing one thing well:
+
+| Piece | Role |
+|---|---|
+| **Garage** (`cove-media` bucket) | Stores one canonical, high-resolution copy of every uploaded image. S3-compatible, in-cluster. |
+| **imgproxy** | Generates resized / re-encoded variants on the fly from the canonical source. Open-source, libvips-backed, runs as a single Deployment in the cluster. |
+| **Cloudflare** | Caches every uniquely-URL'd variant at the edge. Once warmed, the cluster never sees that exact URL again. |
+
+The principle that ties them together: **one source of truth, infinite derived views.** Vendors upload once. imgproxy turns that one source into whatever shape a screen needs. Cloudflare remembers every shape and serves it from the edge. The cluster pays the transformation cost exactly once per (image, variant) combination.
+
+---
+
+## Data model
+
+A product owns zero or more media items. The primary image is used in every list view; gallery images show up on the detail screen carousel.
+
+```sql
+CREATE TABLE product.product_media (
+    id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    product_id  uuid        NOT NULL REFERENCES product.products(id) ON DELETE CASCADE,
+    media_key   text        NOT NULL,                 -- Garage object key (content-addressed)
+    role        text        NOT NULL CHECK (role IN ('primary', 'gallery')),
+    sort_order  integer     NOT NULL DEFAULT 0,
+    alt_text    text,                                 -- accessibility, future SEO
+    width       integer     NOT NULL,                 -- source dimensions (for layout hints)
+    height      integer     NOT NULL,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+
+    -- Exactly one primary per product. Deferrable so vendors can swap
+    -- primary in a single transaction (DELETE + INSERT or two UPDATEs).
+    UNIQUE (product_id, role) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE INDEX ON product.product_media (product_id, sort_order);
+```
+
+Notes:
+
+- **`media_key` is content-addressed.** `cove-image` writes objects under `<sha256-of-bytes>.webp`, so the same upload twice never wastes storage and never overwrites a different image.
+- **`width` / `height` are source dimensions.** Clients use these to reserve layout space *before* the image loads, eliminating layout shift in list views.
+- **No `image_key` column on `products`.** The primary image is `WHERE role = 'primary'` on this table; list queries pull it via a `LATERAL JOIN`.
+- **`ON DELETE CASCADE`.** Deleting a product removes its media rows automatically. (The Garage objects themselves are pruned by a separate cleanup job — see "Garbage collection" below.)
+
+### Why a child table, not multiple columns on `products`
+
+A `primary_image_key` + `gallery_image_keys jsonb` shape on `products` would work for v1 but:
+
+- Variable-cardinality gallery items model badly in flat columns
+- Sort order would either live in the JSONB (awkward to UPDATE) or require renaming columns
+- Cascade behavior is cleaner with a real child table
+- Alt text and source dimensions need somewhere structured to live
+
+The child-table cost is one JOIN per product on list queries — indexed, negligible.
+
+---
+
+## Variant catalog
+
+A small, fixed catalog of sizes. Server-defined; clients pick by name.
+
+| Variant | Dimensions | Used for |
+|---|---|---|
+| `thumb` | 200 × 200 | Search result thumbnails, small grid views (1×) |
+| `sm` | 400 × 400 | List views (2×), avatar-like contexts |
+| `md` | 800 × 800 | Detail hero (1×) / list views (3× on Pro iPhones) |
+| `lg` | 1600 × 1600 | Detail hero / carousel (2×) |
+| `xl` | 3200 × 3200 | Retina desktop / future web client |
+
+All variants resize with `fill` mode (crop overflow to exact square dimensions). Output format is WebP for v1; AVIF support can be added with a new variant suffix without disturbing existing URLs.
+
+### Why a fixed catalog, not arbitrary client-requested dimensions
+
+| Aspect | Fixed catalog (chosen) | Arbitrary dimensions |
+|---|---|---|
+| CDN cache hit rate | Bounded set of URLs per image — predictable | Each unique dimension fragments cache; near-duplicates never share a hit |
+| Signing surface | Server signs only catalog URLs; client cannot ask for any other | Server has to sign anything the client asks for, or expose the signing key |
+| Forward compatibility | Add a new variant by deploying server config | No central place to manage available sizes |
+| iOS implementation | Switch over a known enum | Compute pixel dimensions everywhere |
+
+### Adding a new variant
+
+When the future web client needs `2k` (2048 × 2048) for retina laptops:
+
+1. Add the row to the catalog (single config value in `cove-product` / `cove-image`)
+2. Server starts including `2k` in response shapes that already return the full set (or add it to specific endpoints)
+3. Clients that know about it use it; clients that don't ignore it
+
+No migration. No URL rotation. No cache invalidation.
+
+---
+
+## Serving variants
+
+Response shapes differ by endpoint — list views need one image with a few sizes; detail views need the full gallery with the full size set.
+
+### List endpoint (e.g. search, browse)
+
+OpenAPI schema:
+
+```yaml
+ProductSummary:
+  properties:
+    id:         { type: string, format: uuid }
+    name:       { type: string }
+    priceCents: { type: integer }
+    vendorName: { type: string }
+    primaryImage:
+      $ref: '#/components/schemas/ImageVariants'
+
+ImageVariants:
+  required: [width, height]
+  properties:
+    width:   { type: integer }
+    height:  { type: integer }
+    altText: { type: string }
+    thumb:   { type: string, format: uri }
+    sm:      { type: string, format: uri }
+    md:      { type: string, format: uri }
+```
+
+SQL backing it (search query, primary image only):
+
+```sql
+SELECT
+    p.id, p.name, p.price_cents,
+    v.name AS vendor_name,
+    m.media_key, m.width, m.height, m.alt_text
+FROM product.products p
+JOIN vendor.vendors v ON v.id = p.vendor_id
+LEFT JOIN LATERAL (
+    SELECT media_key, width, height, alt_text
+    FROM product.product_media
+    WHERE product_id = p.id AND role = 'primary'
+    LIMIT 1
+) m ON TRUE
+WHERE p.is_active
+  AND p.search_vec @@ websearch_to_tsquery('english', $1)
+ORDER BY ts_rank(p.search_vec, websearch_to_tsquery('english', $1)) DESC
+LIMIT $2;
+```
+
+The Go handler then signs three imgproxy URLs per result (`thumb`, `sm`, `md`) and assembles the response.
+
+### Detail endpoint
+
+OpenAPI schema:
+
+```yaml
+ProductDetail:
+  properties:
+    # ...all the product fields...
+    media:
+      type: array
+      items: { $ref: '#/components/schemas/ProductMedia' }
+
+ProductMedia:
+  required: [role, width, height]
+  properties:
+    role:    { type: string, enum: [primary, gallery] }
+    altText: { type: string }
+    width:   { type: integer }
+    height:  { type: integer }
+    variants:
+      properties:
+        thumb: { type: string, format: uri }
+        sm:    { type: string, format: uri }
+        md:    { type: string, format: uri }
+        lg:    { type: string, format: uri }
+        xl:    { type: string, format: uri }
+```
+
+SQL fetches the full gallery for the product:
+
+```sql
+SELECT id, media_key, role, sort_order, alt_text, width, height
+FROM product.product_media
+WHERE product_id = $1
+ORDER BY sort_order;
+```
+
+The handler signs all five variants per media item.
+
+### Payload size
+
+A list response with 25 results × 3 variant URLs (~200 chars each) is ~15 KB just in image URLs — fine over modern mobile networks, cheaper than fetching extra metadata. Detail responses with 6 media items × 5 variants are ~6 KB — also fine.
+
+---
+
+## Picking variants on iOS
+
+The client knows two things: the rendering context (target point size) and the device pixel scale (`UIScreen.main.scale` or the SwiftUI environment equivalent).
+
+```swift
+extension ImageVariants {
+    /// Pick the smallest variant whose width meets or exceeds the target pixel size.
+    /// Falls back to the largest available if the target exceeds the catalog.
+    func url(forTargetPointSize size: CGFloat,
+             scale: CGFloat = UIScreen.main.scale) -> URL? {
+        let target = size * scale
+        let candidate: String?
+        switch target {
+        case ..<300:   candidate = thumb
+        case ..<600:   candidate = sm
+        case ..<1200:  candidate = md
+        case ..<2400:  candidate = lg
+        default:       candidate = xl
+        }
+        return candidate.flatMap(URL.init(string:))
+    }
+}
+
+// Usage
+AsyncImage(url: product.primaryImage.url(forTargetPointSize: 150)) { phase in
+    switch phase {
+    case .success(let image): image.resizable().scaledToFill()
+    case .failure:            Color.gray
+    case .empty:              ProgressView()
+    @unknown default:         EmptyView()
+    }
+}
+.aspectRatio(
+    product.primaryImage.width / product.primaryImage.height,
+    contentMode: .fill
+)
+.frame(width: 150, height: 150)
+.clipped()
+```
+
+The `width`/`height` from the response means the `AsyncImage` reserves its space before the bytes arrive — no layout shift when the image loads in.
+
+For a future web client, the same response shape maps directly to `<picture>` with `srcset` (no client-side variant-selection logic needed; the browser does it).
+
+---
+
+## Vendor upload flow
+
+Vendors upload once; the server handles everything that needs to be identical across products.
+
+### Minimum requirements (enforced server-side in `cove-image`)
+
+| Requirement | Value | Why |
+|---|---|---|
+| Minimum dimensions | 2000 × 2000 | Need clean downscale to `xl` (3200) without upscaling artifacts on retina displays |
+| Maximum dimensions | 8000 × 8000 | Cap imgproxy memory/CPU per transformation |
+| Maximum file size | 20 MB | Generous for high-quality phone or DSLR shots |
+| Accepted formats | JPEG, PNG, WebP, HEIC | HEIC is iPhone's default; accepting it removes friction for vendors |
+| Aspect ratio | Any (documented preference: square or 4:3 for catalog browsing) | Server `fill`-crops to square variants regardless |
+
+These are returned in a structured error response when violated so the client can show a useful message ("Image must be at least 2000×2000 pixels").
+
+### Normalization pipeline
+
+After accepting the upload, `cove-image` runs the bytes through libvips before writing to Garage:
+
+```
+1. Decode source format            (handles HEIC, JPEG, PNG, WebP)
+2. Auto-rotate from EXIF flag      (phone photos often have rotation set)
+3. Strip EXIF metadata             (privacy: removes GPS coordinates; size win)
+4. Convert color space to sRGB     (consistency across devices and imgproxy reads)
+5. Re-encode as WebP, quality 90   (high-fidelity, compact)
+6. Compute SHA-256 of resulting bytes
+7. Write to Garage as cove-media/<sha256>.webp
+8. Return { key, width, height } to the caller
+```
+
+Why each step matters:
+
+- **Strip EXIF** — phone photos embed GPS coordinates by default. Without this, every product image leaks the vendor's location.
+- **Auto-rotate** — phones store the image with the sensor's native orientation and a separate rotation flag. Without rotating during decode, half the uploads display sideways.
+- **sRGB color space** — Adobe RGB and P3 sources render with shifted colors when imgproxy converts them at delivery time. Normalizing once on upload avoids surprises.
+- **WebP quality 90** — visually lossless; ~40-60% smaller than the equivalent JPEG. Cheap storage win.
+- **Content-addressed key** — if a vendor uploads the same image twice (different products, same source photo), Garage stores one object. If a vendor mid-upload retries, we don't pollute storage with half-written objects.
+
+### Associating with a product
+
+Upload is decoupled from product association:
+
+1. Vendor app calls `POST /images` with the image bytes → response: `{ media_key, width, height }`
+2. Vendor app calls `POST /products` (or `PATCH`) with the desired role: `{ media_key, role: 'primary' }`
+3. `cove-product` inserts into `product_media`
+
+This split means a vendor can upload several images and then arrange them — no need for the upload endpoint to know about products.
+
+---
+
+## The imgproxy URL — anatomy
+
+Every variant URL the server returns looks like this:
+
+```
+https://api.coveapp.dev/i/<sig>/rs:fill:600:600/plain/s3://cove-media/<key>.webp@webp
+└─────┬──────────┘  └┬┘ └─┬┘ └──────┬───────┘  └──┬──┘ └──────┬──────────┘  └─┬─┘
+   public host       │  signature  processing      source     S3 source URL    output
+                    path           options          format    (Garage)        format
+                    prefix
+```
+
+| Component | What it does |
+|---|---|
+| `https://api.coveapp.dev` | Public hostname (Cloudflare Tunnel) |
+| `/i/` | Path prefix routed to imgproxy via cove-gateway. **Not Bearer-authenticated** — see [Auth model](#auth-model) below. |
+| `<sig>` | HMAC-SHA256 signature over the path. Server-side secret. Prevents URL forgery. |
+| `rs:fill:600:600` | imgproxy processing options. `rs` = resize, `fill` = crop to fill exact dimensions. Other options chainable: `rs:fill:600:600/q:80/bg:fff`. |
+| `plain/` | Source URL format mode. `plain` keeps the source URL human-readable; alternative is base64. |
+| `s3://cove-media/<key>.webp` | The source for imgproxy to fetch. imgproxy is configured (via env) to resolve `s3://` against the in-cluster Garage endpoint. |
+| `@webp` | Output format. imgproxy transcodes to this regardless of source format. |
+
+### Signing in Go
+
+```go
+type ImgproxyClient struct {
+    PublicBaseURL string  // "https://api.coveapp.dev"
+    Key           []byte  // IMGPROXY_KEY (from ESO secret)
+    Salt          []byte  // IMGPROXY_SALT (from ESO secret)
+}
+
+func (c *ImgproxyClient) SignedURL(bucket, key, variant string) string {
+    width, height := variantDimensions(variant)  // looks up the catalog
+    path := fmt.Sprintf(
+        "/rs:fill:%d:%d/plain/s3://%s/%s@webp",
+        width, height, bucket, key,
+    )
+    mac := hmac.New(sha256.New, c.Key)
+    mac.Write(c.Salt)
+    mac.Write([]byte(path))
+    sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+    return fmt.Sprintf("%s/i/%s%s", c.PublicBaseURL, sig, path)
+}
+```
+
+The signing key + salt are 32+ byte random values stored in GCP Secret Manager and synced into the cluster via ExternalSecret. The same values are mounted into the imgproxy Deployment as `IMGPROXY_KEY` and `IMGPROXY_SALT`.
+
+If the keys ever drift, every URL signed with one fails verification on the other — a clear, loud failure mode (every image returns 403).
+
+---
+
+## Auth model
+
+This is the most nuanced part of the architecture. Image URLs need to coexist with three constraints:
+
+1. **Cloudflare wants to cache by URL.** Per-user URLs destroy hit rate.
+2. **`<img src>` and `AsyncImage` don't add auth headers.** Custom URLSession wiring at every image-loading site is unworkable.
+3. **The catalog is a marketplace.** Product images are inherently meant to be seen by potential buyers.
+
+### The four options
+
+| Option | How it works | CDN-friendly | Right for |
+|---|---|---|---|
+| **A. Public signed URLs** | Signature makes URL unguessable; anyone with the URL can fetch | ✅ Yes — same URL for all users | Public catalog images |
+| **B. Per-user signed URLs** | Server signs with user UID embedded; each user gets a unique URL | ❌ No — cache fragments per user | Private documents per user |
+| **C. Short-lived signed URLs** | Signature includes expiration; URL works for a window (e.g. 1 hour) | ⚠️ Within the validity window, yes; URLs rotate when keys do | Vendor drafts, time-limited access |
+| **D. Token-protected URLs** | Every fetch requires a Bearer header | ❌ No — every user pays full transformation cost | Genuinely private data with no cacheability requirement |
+
+### Recommendation for Cove
+
+**Per-image-class strategy:**
+
+| Image class | Strategy | Expiry |
+|---|---|---|
+| Active catalog (`is_active = true` on the product) | Option A — public signed | Effectively unlimited |
+| Vendor drafts (`is_active = false`, not yet published) | Option C — short-lived signed | 1 hour, refreshed via authenticated endpoint |
+| Truly private (future: vendor verification documents, receipts) | Option D — token-protected | Per-request auth, no CDN |
+
+The implementation is straightforward: `cove-product` checks the product state when constructing the URL and decides which signing mode to use. imgproxy's `IMGPROXY_TOKEN_EXP` config supports verifying the expiry portion of the signature.
+
+### "But the catalog is auth-only — why is the image URL public?"
+
+Image **URLs** are public; the **API that produces them** is not. To discover a product image's URL, a client must first call `/products/search` or `/products/{id}` with a valid Firebase ID Token. The Bearer-token check at `cove-gateway` happens *before* the URL is returned.
+
+Once a URL is in hand, anyone can fetch the bytes — but the URL is unguessable (HMAC-SHA256 signature), and you can't enumerate them without going through the authenticated API. This is the same pattern Etsy, Shopify storefronts, Amazon product images, and every major marketplace uses. Authenticated image serving is reserved for things like medical records, financial documents, and other categories where bytes leaking would be a real harm — not for product catalog images.
+
+---
+
+## Caching
+
+The architecture is layered specifically so the cluster does each transformation **once, ever**:
+
+```
+Layer        Caches                          Lifetime
+─────        ──────                          ────────
+Cloudflare   Variant URL → variant bytes     1 year (immutable URLs)
+imgproxy     (none; relies on Cloudflare)    —
+Cluster      Garage → original bytes         indefinite
+```
+
+### Cache hit rate
+
+For a typical catalog browse session:
+- First user to view product X at variant `md`: imgproxy transforms (~30-80ms libvips), Cloudflare caches
+- Every subsequent user requesting the same variant URL: served from Cloudflare edge (~10-30ms total round-trip), cluster never sees the request
+
+Because URLs are deterministic (same source key + same variant = same URL across all callers), every product's variants converge to the cache quickly. The cluster's imgproxy pod handles a small, bounded number of transformations: **(images uploaded) × (variants in catalog)**. At 1,000 products with 5 images each and a 5-variant catalog, that's 25,000 transformations across the lifetime of the product. Negligible.
+
+### Cache headers from imgproxy
+
+```http
+Cache-Control: public, max-age=31536000, immutable
+ETag: "<sha256-of-bytes>"
+```
+
+`immutable` tells Cloudflare (and browser caches) that the URL's response will never change — they can serve from cache without revalidation. This is safe because the URL itself encodes the content (via `media_key` = SHA-256 of source bytes). If the source changes, it gets a new key, which produces new URLs.
+
+### When does the cache miss?
+
+- First request for a (source, variant) combination since deployment
+- A new variant is added to the catalog
+- The signing key rotates (every URL becomes invalid → forces re-signing on the server and re-fetching by clients)
+
+The first two are normal cache-warm scenarios. The third is operationally significant: rotate keys rarely (or not at all), and have a plan if you need to.
+
+---
+
+## Pre-warming
+
+Optionally, `cove-image` can pre-warm Cloudflare's cache right after a successful upload:
+
+```go
+go func(key string) {
+    for _, variant := range []string{"thumb", "sm", "md", "lg", "xl"} {
+        url := imgproxy.SignedURL(bucket: "cove-media", key, variant)
+        // HEAD request: warms Cloudflare's cache without downloading bytes
+        _, _ = http.Head(url)
+    }
+}(key)
+```
+
+Errors are ignored — if pre-warming fails, the first real user request just triggers a normal cache miss and continues. This is purely opportunistic optimization to make the first user of a new product see snappy load times.
+
+For products with very high traffic, the variants stay warm at the Cloudflare edge naturally; pre-warming is mostly useful for the long tail (new products, infrequently-viewed items where the cache might have evicted).
+
+---
+
+## Garbage collection
+
+When a product is deleted, `ON DELETE CASCADE` removes its `product_media` rows. The Garage objects themselves are **not** automatically removed — we want to keep them briefly in case a vendor changes their mind, and content-addressing means the same image might still be referenced by another product.
+
+A small periodic job sweeps unreferenced objects:
+
+```sql
+-- Find Garage keys referenced by no product_media row.
+-- Run weekly; delete objects older than 30 days that don't appear in this query.
+SELECT DISTINCT media_key FROM product.product_media;
+```
+
+The job lists Garage objects, diffs against the SELECT, and deletes any object that is:
+- Not referenced in `product_media`
+- Older than 30 days (gives vendors a window to recover)
+
+This stays out of the hot path entirely.
+
+---
+
+## What's deferred
+
+These are real future requirements but explicitly out of scope for v1:
+
+- **Videos** — would need a separate pipeline (HLS/DASH transcoding, manifest generation, per-bandwidth renditions). No imgproxy equivalent for video that fits this stack cleanly.
+- **Documents** (vendor certifications, ingredient lists as PDFs) — would use Option D (token-protected, no transformation, just signed-URL serving).
+- **Watermarking** — imgproxy supports it; not a v1 product requirement.
+- **AI-driven cropping** (face detection, salient-object detection) — imgproxy supports `gravity:smart`; defer until v1 catalog shows it's needed.
+- **AVIF output** — modern format, ~20% smaller than WebP. Add as a new variant suffix when iOS / web client adoption justifies the imgproxy CPU cost increase.
+- **Per-vendor signing keys** — would let us revoke one vendor's image access without rotating the global key. Defer until vendor portal exists.
+
+Each of these can slot in without disturbing the v1 architecture — add a new endpoint, new variant, new field on `product_media`, or new background job. The data model and serving model don't need to change to accommodate them.
+
+---
+
+## References
+
+- [Marketplace Architecture](MARKETPLACE_ARCHITECTURE.md) — the broader service layout and data model
+- [Category & Product Architecture](CATEGORY_AND_PRODUCT_ARCHITECTURE.md) — product schema and category hierarchy
+- [Postgres Primer](POSTGRES_PRIMER.md) — Postgres mechanics
+- [Backend Infrastructure](BACKEND_INFRASTRUCTURE.md) — cluster topology, deployment, Garage
+- [imgproxy documentation](https://docs.imgproxy.net/) — full options reference, signing details, deployment guides

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ Welcome to the documentation for the Cove iOS app.
 
 ### Backend Reference
 - **[Postgres Primer](POSTGRES_PRIMER.md)** - Schemas, indexes, EXPLAIN ANALYZE, transactions, JSONB, full-text search, and ltree — the concepts Cove's backend depends on
+- **[Media Architecture](MEDIA_ARCHITECTURE.md)** - Image storage in Garage, on-the-fly transformation via imgproxy, the variant catalog, vendor upload normalization, signed-URL auth model, and Cloudflare caching
 
 ### Feature Planning
 - **[LLM Integration Ideas](LLM_INTEGRATION_IDEAS.md)** - Potential ways to incorporate LLMs as production features
@@ -72,6 +73,9 @@ Welcome to the documentation for the Cove iOS app.
 
 ### I'm starting Phase 3 schema work and need to ramp on Postgres
 → Read [Postgres Primer](POSTGRES_PRIMER.md)
+
+### I'm working on image uploads, serving, or anything imgproxy-related
+→ Read [Media Architecture](MEDIA_ARCHITECTURE.md)
 
 ---
 


### PR DESCRIPTION
## Summary

Captures the image storage / transformation / serving architecture as a dedicated reference doc, and updates the existing docs to point at it. The pipeline spans Garage (storage), imgproxy (transformation), Cloudflare (caching), and the vendor upload normalization flow — too much to live cleanly inside `MARKETPLACE_ARCHITECTURE.md` or `CATEGORY_AND_PRODUCT_ARCHITECTURE.md`.

## New: `docs/MEDIA_ARCHITECTURE.md`

| Section | What it covers |
|---|---|
| Mental model | Garage + imgproxy + Cloudflare CDN, why each piece |
| Data model | `product_media` child table (replaces `products.image_key`) with role, sort order, source dimensions, alt text |
| Variant catalog | 5 standard sizes (`thumb`, `sm`, `md`, `lg`, `xl`), rationale for a fixed catalog, how to add new ones |
| Serving variants | Server response shapes differ by endpoint (list vs detail); LATERAL JOIN SQL for primary-image lookups |
| iOS variant selection | `ImageVariants.url(forTargetPointSize:)` pattern; layout-shift prevention via source dimensions |
| Vendor upload | Minimum requirements + normalization pipeline (EXIF strip, sRGB, WebP encode, SHA-256 content-addressed keys) |
| imgproxy URL anatomy | Host, signature, processing options, source URL, output format — with Go signing code |
| Auth model | Public signed (catalog), short-lived signed (drafts), token-protected (truly private) — recommendation per image class |
| Caching | Cloudflare edge + imgproxy + signature determinism; `Cache-Control: immutable` |
| Pre-warming | Opportunistic post-upload variant generation |
| Garbage collection | Periodic cleanup of unreferenced Garage objects |
| What's deferred | Videos, documents, watermarking, AI cropping, AVIF, per-vendor signing keys |

## Companion updates

- **`MARKETPLACE_ARCHITECTURE.md`** — `image_key` column dropped from `products`; `product_media` added to entities table and schema SQL; Favorites query updated to `LATERAL JOIN` against `product_media`; new cross-link.
- **`CATEGORY_AND_PRODUCT_ARCHITECTURE.md`** — `image_key` removed from products example; worked queries (category browse, facet filter, product detail) updated to JOIN `product_media`; new cross-link.
- **`README.md`** — new Backend Reference entry; new "Which document?" entry for image-related work.

## Acceptance criteria from #285

- [x] New file `docs/MEDIA_ARCHITECTURE.md`
- [x] All required sections (mental model, data model, variant catalog, serving, client selection, upload, URL anatomy, auth, caching, pre-warming, deferred)
- [x] `MARKETPLACE_ARCHITECTURE.md` updated (drops `image_key`, adds `product_media` to entities + schema, cross-links)
- [x] `CATEGORY_AND_PRODUCT_ARCHITECTURE.md` updated (removes `image_key` from products example, cross-links)
- [x] `docs/README.md` updated with new doc entry

## Follow-up

After merging, comment on Phase 2 epic (#237) and sub-issues (#239, #240, #243) noting that the architecture is now documented; those sub-issues' acceptance criteria can be tightened to reference this doc when Phase 2 work begins.

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)