### PR TITLE
Add table of contents to long docs + glossary to POSTGRES_PRIMER

### DIFF
--- a/docs/APP_ARCHITECTURE.md
+++ b/docs/APP_ARCHITECTURE.md
@@ -2,6 +2,21 @@
 
 This document covers the Cove iOS app's architecture — how it's structured, how data flows, and how key systems work.
 
+## Contents
+
+- [Overview](#overview)
+- [Project Structure](#project-structure)
+- [Authentication & Navigation](#authentication--navigation)
+- [Tab Structure](#tab-structure)
+- [ViewModels](#viewmodels)
+- [Global State](#global-state)
+- [Product Type System](#product-type-system)
+- [Firebase Data Model](#firebase-data-model)
+- [Key Data Flows](#key-data-flows)
+- [Not Yet Implemented](#not-yet-implemented)
+
+---
+
 ## Overview
 
 Cove uses **MVVM (Model-View-ViewModel)** with SwiftUI. State is managed through a combination of `@StateObject`, `@EnvironmentObject`, and `@Published` properties. Firebase is the sole backend — Firestore for data, Firebase Auth for authentication, and Cloud Storage for images.

--- a/docs/BACKEND_INFRASTRUCTURE.md
+++ b/docs/BACKEND_INFRASTRUCTURE.md
@@ -2,6 +2,21 @@
 
 > **Status:** Phase 0 complete. The cluster is fully bootstrapped and running. The iOS app still uses Firebase directly — backend services come online in Phases 1–3 one at a time. Firebase Auth is kept throughout.
 
+## Contents
+
+- [Goals](#goals)
+- [Architecture](#architecture)
+- [Platform layer (installed, Phase 0)](#platform-layer-installed-phase-0)
+- [Repo structure](#repo-structure)
+- [Service naming](#service-naming)
+- [Container images](#container-images)
+- [Migration phases](#migration-phases)
+- [Manifest conventions](#manifest-conventions)
+- [K3s → GKE migration path](#k3s--gke-migration-path)
+- [References](#references)
+
+---
+
 ## Goals
 
 - Remove reliance on Firebase for data and storage (Auth stays — it's the hardest to replace and provides the most value)

--- a/docs/CATEGORY_AND_PRODUCT_ARCHITECTURE.md
+++ b/docs/CATEGORY_AND_PRODUCT_ARCHITECTURE.md
@@ -2,6 +2,22 @@
 
 > **Status:** Planned design. The current app uses a flat, hardcoded category set. This document describes the post-migration model in Postgres — built alongside `cove-product` in Phase 3.
 
+## Contents
+
+- [Overview](#overview)
+- [Category hierarchy](#category-hierarchy)
+- [Facets and filters, not categories](#facets-and-filters-not-categories)
+- [Products](#products)
+- [Product variants](#product-variants)
+- [Product details (polymorphic)](#product-details-polymorphic)
+- [Full-text search](#full-text-search)
+- [Indexes by query pattern](#indexes-by-query-pattern)
+- [User-facing flows mapped to queries](#user-facing-flows-mapped-to-queries)
+- [What's deliberately not modeled](#whats-deliberately-not-modeled)
+- [References](#references)
+
+---
+
 ## Overview
 
 Cove's catalog has two related modeling problems that pull in different directions:

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -4,6 +4,18 @@ This document is the authoritative reference for Cove's design system. It maps F
 
 **Figma file:** [Cove](https://www.figma.com/design/PQWPBacMcEeXzDyi7aalZY/Cove)
 
+## Contents
+
+- [Figma File Structure](#figma-file-structure)
+- [Color System](#color-system)
+- [Typography](#typography)
+- [Spacing](#spacing)
+- [Corner Radius](#corner-radius)
+- [Shadow](#shadow)
+- [Components](#components)
+- [Rules & Anti-Patterns](#rules--anti-patterns)
+- [Roadmap & Known Gaps](#roadmap--known-gaps)
+
 ---
 
 ## Figma File Structure

--- a/docs/MARKETPLACE_ARCHITECTURE.md
+++ b/docs/MARKETPLACE_ARCHITECTURE.md
@@ -2,6 +2,21 @@
 
 > **Status:** Planned backend. The app currently uses Firebase (Firestore + Auth + Storage) exclusively. This document describes the target marketplace data layer Cove is migrating to — see [Backend Infrastructure](BACKEND_INFRASTRUCTURE.md) for the cluster and phase plan.
 
+## Contents
+
+- [Overview](#overview)
+- [Services](#services)
+- [Single Postgres cluster, schemas per service](#single-postgres-cluster-schemas-per-service)
+- [Entities (v1)](#entities-v1)
+- [Database schema](#database-schema)
+- [Request flow: fetching a product page](#request-flow-fetching-a-product-page)
+- [iOS networking layer](#ios-networking-layer)
+- [Deployment](#deployment)
+- [References](#references)
+- [Revision history](#revision-history)
+
+---
+
 ## Overview
 
 Cove is a discovery platform for local producers and businesses. Users browse vendors and their products and save favorites. Purchases happen in person — there is no order management or payment processing in v1.

--- a/docs/MEDIA_ARCHITECTURE.md
+++ b/docs/MEDIA_ARCHITECTURE.md
@@ -2,6 +2,25 @@
 
 > **Status:** Planned — built in Phase 2 alongside `cove-image`. v1 covers product images only; videos and documents are deferred. The bucket `cove-media` is already provisioned in Garage.
 
+## Contents
+
+- [Overview](#overview)
+- [The mental model](#the-mental-model)
+- [Data model](#data-model)
+- [Variant catalog](#variant-catalog)
+- [Serving variants](#serving-variants)
+- [Picking variants on iOS](#picking-variants-on-ios)
+- [Vendor upload flow](#vendor-upload-flow)
+- [The imgproxy URL — anatomy](#the-imgproxy-url--anatomy)
+- [Auth model](#auth-model)
+- [Caching](#caching)
+- [Pre-warming](#pre-warming)
+- [Garbage collection](#garbage-collection)
+- [What's deferred](#whats-deferred)
+- [References](#references)
+
+---
+
 ## Overview
 
 Every product in Cove has at least one image, and most have a small gallery. Those images need to:

--- a/docs/MEDIA_ARCHITECTURE.md
+++ b/docs/MEDIA_ARCHITECTURE.md
@@ -431,12 +431,25 @@ Because URLs are deterministic (same source key + same variant = same URL across
 
 ### Cache headers from imgproxy
 
+The Cloudflare edge cache doesn't kick in automatically for our URL pattern — the path ends in `@webp` (imgproxy's output format suffix), not `.webp`, so Cloudflare's static-asset extension heuristic doesn't match. What actually triggers caching is the **origin response headers** imgproxy sends:
+
 ```http
 Cache-Control: public, max-age=31536000, immutable
 ETag: "<sha256-of-bytes>"
 ```
 
-`immutable` tells Cloudflare (and browser caches) that the URL's response will never change — they can serve from cache without revalidation. This is safe because the URL itself encodes the content (via `media_key` = SHA-256 of source bytes). If the source changes, it gets a new key, which produces new URLs.
+Cloudflare's default "Respect Origin Headers" behavior on the Free plan caches based on these regardless of URL pattern. `immutable` tells Cloudflare (and browser caches) that the URL's response will never change — they can serve from cache without revalidation. This is safe because the URL itself encodes the content (via `media_key` = SHA-256 of source bytes). If the source changes, it gets a new key, which produces new URLs.
+
+### Cloudflare configuration
+
+The Free plan covers everything we need: edge caching, ~~unlimited~~ bandwidth, basic DDoS protection. The paid features (Argo Smart Routing, Tiered Cache, Cache Reserve) trim 20-30ms off transit and matter at much higher traffic — they're not load-bearing for Cove.
+
+Optionally, a single Cache Rule in the Cloudflare dashboard provides belt-and-suspenders coverage and lets you override TTL without redeploying imgproxy:
+
+- **Match:** Hostname is `api.coveapp.dev` AND URI Path matches `/i/*`
+- **Action:** Eligible for cache, Edge TTL 1 year
+
+Free plan allows up to 5 Cache Rules. With the origin headers above already doing the work, this rule is optional.
 
 ### When does the cache miss?
 

--- a/docs/POSTGRES_PRIMER.md
+++ b/docs/POSTGRES_PRIMER.md
@@ -4,6 +4,19 @@ A focused ramp-up on the Postgres concepts Cove's backend depends on. The goal i
 
 Assumed starting point: comfortable with Firestore, new to relational databases.
 
+## Contents
+
+- [The database layout](#the-database-layout)
+- [Schemas and search_path](#schemas-and-search_path)
+- [Indexes: B-tree, GIN, and partial](#indexes-b-tree-gin-and-partial)
+- [EXPLAIN ANALYZE](#explain-analyze)
+- [Transactions and isolation levels](#transactions-and-isolation-levels)
+- [JSONB](#jsonb)
+- [Full-text search with tsvector and tsquery](#full-text-search-with-tsvector-and-tsquery)
+- [Category hierarchy with ltree](#category-hierarchy-with-ltree)
+- [Quick reference](#quick-reference)
+- [Glossary](#glossary)
+
 ---
 
 ## The database layout
@@ -511,3 +524,46 @@ EXPLAIN ANALYZE SELECT ...
 -- Refresh statistics after large data loads
 ANALYZE products;
 ```
+
+---
+
+## Glossary
+
+Quick lookups for terms used throughout. For full context, see the corresponding sections above.
+
+**B-tree** — The default Postgres index type. Used for equality, range queries, and sorting on scalar columns. Created with a plain `CREATE INDEX`.
+
+**Cross-schema FK** — A foreign key whose target column lives in a different schema in the same database (e.g. `"user".favorites.product_id` → `product.products(id)`). Works natively; foundational to Cove's single-cluster-schemas-per-service topology.
+
+**EXPLAIN ANALYZE** — A Postgres command that runs a query and reports the actual execution plan with wall-clock timings. The first tool to reach for when a query is slower than expected.
+
+**Generated column** — A column whose value is computed by an expression over other columns in the same row. `STORED` keeps the result on disk so it can be indexed. Used for `search_vec` to keep it in sync with `name` + `description` automatically.
+
+**GIN** — Generalized Inverted Index. Indexes the *contents* of composite values: JSONB keys, array elements, tsvector lexemes. Required for `@>` containment, `?` key-exists, and `@@` full-text matches.
+
+**GiST** — Generalized Search Tree. The index type used by `ltree` for hierarchical operators (`<@`, `@>`, `~`).
+
+**JSONB** — Binary-stored, queryable, indexable JSON. Preferred over `json` for any column you'll query. Operators: `->` (get as JSONB), `->>` (get as text), `@>` (contains), `?` (key exists).
+
+**ltree** — Postgres extension that stores hierarchical labels as a single dot-separated column (`food.produce.honey`). Operators include `<@` (is descendant of), `@>` (is ancestor of), `~` (matches lquery pattern), `nlevel()` (depth).
+
+**Partial index** — An index with a `WHERE` clause covering only matching rows. Smaller, faster, and the right tool when most rows are irrelevant to most queries (e.g., active products only).
+
+**Read committed** — Postgres's default isolation level. Each statement sees a fresh snapshot of committed data. Two reads of the same row in one transaction may return different values if another transaction committed in between.
+
+**Repeatable read** — An isolation level where the entire transaction sees the snapshot taken at its start. Use when you need consistency across multiple reads in one transaction.
+
+**Role** — A Postgres "user" with login and permission grants. Services connect as their own role (`cove_product`, `cove_user`) so schema ownership is enforced at the database level.
+
+**Schema** — A namespace inside a Postgres database that groups tables, functions, and types. Cove uses one schema per service (`product`, `vendor`, `user`) within a single `cove` database.
+
+**search_path** — Ordered list of schemas Postgres checks for unqualified names. Each service's role has its own schema first, so application queries stay unqualified (`SELECT * FROM products` works inside `cove-product` because `search_path = product, public`).
+
+**Serializable** — The strictest isolation level — transactions behave as if they ran one at a time. Rarely needed; comes with occasional retry on conflict.
+
+**tsquery** — A search expression parsed from user input (via `to_tsquery` or `websearch_to_tsquery`). Combined with `@@` to match against a tsvector.
+
+**tsvector** — Pre-processed representation of a document (normalized lexemes + positions) used for full-text search. Typically stored as a generated column from `name` + `description` and indexed with GIN.
+
+**websearch_to_tsquery** — A forgiving tsquery parser for user-typed search input. Handles phrases (`"raw honey"`), negations (`organic -processed`), and never throws on invalid syntax. Use this for app search bars; use `to_tsquery` for programmatic queries.
+


### PR DESCRIPTION
## Summary

The architecture and reference docs have grown long enough that top-to-bottom reading isn't always the access pattern. Adds a short, top-of-doc "Contents" section to seven docs, a glossary at the bottom of POSTGRES_PRIMER, and a small clarification to MEDIA_ARCHITECTURE about how Cloudflare edge caching actually triggers for the imgproxy `/i/*` URL pattern.

## Docs touched

| Doc | Sections | TOC | Glossary | Other |
|---|---|---|---|---|
| `MEDIA_ARCHITECTURE.md` | 14 | ✅ | — | Caching section clarified |
| `MARKETPLACE_ARCHITECTURE.md` | 10 | ✅ | — | |
| `CATEGORY_AND_PRODUCT_ARCHITECTURE.md` | 11 | ✅ | — | |
| `BACKEND_INFRASTRUCTURE.md` | 10 | ✅ | — | |
| `POSTGRES_PRIMER.md` | 10 | ✅ | ✅ (~18 terms) | |
| `APP_ARCHITECTURE.md` | 10 | ✅ | — | |
| `DESIGN_SYSTEM.md` | 9 | ✅ | — | |

## Skipped

Linear / shorter docs that read top-to-bottom without needing navigation:

- `QUICK_START.md`
- `SECRETS_SETUP.md`
- `CI_CD_WORKFLOWS.md`
- `LLM_INTEGRATION_IDEAS.md`

## Format

Compact bulleted list right after the title's status callout, before the first `---` divider. Anchor links use GitHub's auto-generated IDs from heading text — no manual `id=` tags. The doc viewer's outline panel works in parallel; explicit TOCs work everywhere markdown renders.

## Glossary on POSTGRES_PRIMER

The primer is the densest doc in unfamiliar jargon. Glossary at the bottom covers: B-tree, GIN, GiST, JSONB, ltree, partial indexes, isolation levels (read committed, repeatable read, serializable), roles, schemas, search_path, tsquery, tsvector, websearch_to_tsquery, cross-schema FK, generated columns, EXPLAIN ANALYZE.

Glossary entries are short — the body has the full context. Used as a quick lookup, not as a source-of-truth competitor.

## MEDIA_ARCHITECTURE caching clarification

The Caching section previously read as if Cloudflare just magically caches imgproxy variants. It doesn't — the URL pattern ends in `@webp` (imgproxy's output format suffix), not `.webp`, so Cloudflare's static-asset extension heuristic doesn't fire. What does the work is the `Cache-Control: public, max-age=31536000, immutable` header imgproxy sends, combined with Cloudflare's default "Respect Origin Headers" behavior on the Free plan. Section now spells this out and notes an optional Cache Rule for belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)