### PR TITLE
Add Cove/Networking/ with APIClient, APIRequest, and APIError

### DIFF
--- a/apps/ios/Cove/Networking/APIClient.swift
+++ b/apps/ios/Cove/Networking/APIClient.swift
@@ -1,0 +1,160 @@
+//
+//  APIClient.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/17/26.
+//
+
+import FirebaseAuth
+import Foundation
+import OSLog
+
+// MARK: - APIClient
+
+/// URLSession wrapper that injects a Firebase ID Token as a Bearer credential on every request.
+///
+/// `APIClient` is thread-safe and can be called from any isolation context without blocking
+/// `@MainActor`. Instantiate once and inject wherever needed — ViewModels will receive it
+/// through repository protocols introduced in issues #224–#226.
+///
+/// ```swift
+/// let client = APIClient(baseURL: URL(string: "https://api.coveapp.dev")!)
+/// let result: MyResponse = try await client.send(APIRequest(path: "health"))
+/// ```
+///
+/// > Note: Environment switching (staging vs. prod base URLs) is handled in issue #223.
+final class APIClient: @unchecked Sendable {
+    // MARK: Properties
+
+    /// The base URL prepended to every request path.
+    ///
+    /// Inject a staging URL during testing; prod URL in release builds.
+    /// Issue #223 will provide convenience factory properties for both environments.
+    let baseURL: URL
+
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    private let tokenCache = TokenCache()
+
+    // MARK: Init
+
+    init(
+        baseURL: URL,
+        session: URLSession = .shared,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.decoder = decoder
+    }
+
+    // MARK: Request execution
+
+    /// Sends an authenticated request and decodes the response body into `T`.
+    ///
+    /// The Firebase ID Token is fetched from `TokenCache` — a 50-second in-memory cache that
+    /// avoids redundant `getIDTokenResult` calls in burst scenarios while ensuring tokens
+    /// stay fresh (Firebase rotates them hourly; our TTL is well within that window).
+    ///
+    /// - Throws: `APIError.unauthenticated` when no user is signed in,
+    ///           `APIError.httpError` for non-2xx responses,
+    ///           `APIError.decodingError` when the body cannot be decoded into `T`,
+    ///           `APIError.networkError` for transport failures.
+    func send<T: Decodable>(_ request: APIRequest) async throws -> T {
+        let token = try await tokenCache.validToken()
+
+        var urlRequest = try request.urlRequest(baseURL: baseURL)
+        urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        #if DEBUG
+            APIClient.logRequest(urlRequest)
+        #endif
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: urlRequest)
+        } catch {
+            throw APIError.networkError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.networkError(URLError(.badServerResponse))
+        }
+
+        #if DEBUG
+            APIClient.logResponse(httpResponse, data: data)
+        #endif
+
+        guard (200 ..< 300).contains(httpResponse.statusCode) else {
+            throw APIError.httpError(statusCode: httpResponse.statusCode, data: data)
+        }
+
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw APIError.decodingError(error)
+        }
+    }
+}
+
+// MARK: - TokenCache
+
+/// Actor that caches Firebase ID Tokens for 50 seconds to reduce redundant token fetches
+/// during burst request patterns. Firebase manages the underlying token refresh (1-hour TTL);
+/// this cache is purely an efficiency layer on top.
+private actor TokenCache {
+    private struct Entry {
+        let value: String
+        let expiresAt: Date
+    }
+
+    private static let ttl: TimeInterval = 50
+
+    private var cache: [String: Entry] = [:]
+
+    func validToken() async throws -> String {
+        guard let user = Auth.auth().currentUser else {
+            throw APIError.unauthenticated
+        }
+
+        let now = Date()
+
+        if let entry = cache[user.uid], entry.expiresAt > now {
+            return entry.value
+        }
+
+        let result: AuthTokenResult
+        do {
+            result = try await user.getIDTokenResult(forcingRefresh: false)
+        } catch {
+            // #223 will add a dedicated .authError case; for now wrap as networkError
+            // so callers always receive an APIError.
+            throw APIError.networkError(error)
+        }
+
+        cache[user.uid] = Entry(
+            value: result.token,
+            expiresAt: now.addingTimeInterval(Self.ttl)
+        )
+        return result.token
+    }
+}
+
+// MARK: - Debug logging
+
+#if DEBUG
+    private extension APIClient {
+        static let logger = Logger(subsystem: "com.danicajiao.cove", category: "APIClient")
+
+        static func logRequest(_ request: URLRequest) {
+            let method = request.httpMethod ?? "?"
+            let url = request.url?.absoluteString ?? "?"
+            logger.debug("→ \(method) \(url)")
+        }
+
+        static func logResponse(_ response: HTTPURLResponse, data: Data) {
+            let url = response.url?.absoluteString ?? "?"
+            logger.debug("← \(response.statusCode) \(url) (\(data.count) bytes)")
+        }
+    }
+#endif

--- a/apps/ios/Cove/Networking/APIError.swift
+++ b/apps/ios/Cove/Networking/APIError.swift
@@ -1,0 +1,42 @@
+//
+//  APIError.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/17/26.
+//
+
+import Foundation
+
+/// Typed errors surfaced by `APIClient`.
+///
+/// > Note: This is the initial set for Phase 0. Issue #223 will expand these
+/// > with additional cases and a dedicated `.authError` for Firebase token failures.
+enum APIError: Error {
+    /// No Firebase user is signed in — request cannot be authenticated.
+    case unauthenticated
+    /// The server returned a non-2xx status code.
+    case httpError(statusCode: Int, data: Data)
+    /// The response body could not be decoded into the expected type.
+    case decodingError(Error)
+    /// A transport-level error occurred (e.g. no network, TLS failure).
+    case networkError(Error)
+    /// A valid URL could not be constructed from the provided path and base URL.
+    case badURL
+}
+
+extension APIError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .unauthenticated:
+            "No authenticated user — sign in before making requests."
+        case let .httpError(statusCode, _):
+            "Server returned HTTP \(statusCode)."
+        case let .decodingError(error):
+            "Failed to decode response: \(error.localizedDescription)"
+        case let .networkError(error):
+            "Network error: \(error.localizedDescription)"
+        case .badURL:
+            "Could not construct a valid URL for the request."
+        }
+    }
+}

--- a/apps/ios/Cove/Networking/APIRequest.swift
+++ b/apps/ios/Cove/Networking/APIRequest.swift
@@ -1,0 +1,116 @@
+//
+//  APIRequest.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/17/26.
+//
+
+import Foundation
+
+/// A value type that describes an outbound HTTP request.
+///
+/// Use the plain initializer for GET requests with optional query params,
+/// or the generic `jsonBody:` initializer for POST/PUT/PATCH requests:
+///
+/// ```swift
+/// // GET /health
+/// let ping = APIRequest(path: "health")
+///
+/// // POST /images with a JSON body
+/// let upload = try APIRequest(path: "images", method: .post, jsonBody: metadata)
+/// ```
+struct APIRequest {
+    // MARK: - HTTPMethod
+
+    enum HTTPMethod: String {
+        case get = "GET"
+        case post = "POST"
+        case put = "PUT"
+        case patch = "PATCH"
+        case delete = "DELETE"
+    }
+
+    // MARK: - Properties
+
+    let path: String
+    let method: HTTPMethod
+    let queryItems: [URLQueryItem]
+    let body: Data?
+    let additionalHeaders: [String: String]
+
+    // MARK: - Init
+
+    init(
+        path: String,
+        method: HTTPMethod = .get,
+        queryItems: [URLQueryItem] = [],
+        body: Data? = nil,
+        additionalHeaders: [String: String] = [:]
+    ) {
+        self.path = path
+        self.method = method
+        self.queryItems = queryItems
+        self.body = body
+        self.additionalHeaders = additionalHeaders
+    }
+}
+
+// MARK: - JSON body convenience
+
+extension APIRequest {
+    /// Creates a request with a JSON-encoded body.
+    /// Sets `Content-Type: application/json` automatically.
+    init(
+        path: String,
+        method: HTTPMethod = .post,
+        queryItems: [URLQueryItem] = [],
+        jsonBody: some Encodable,
+        encoder: JSONEncoder = JSONEncoder(),
+        additionalHeaders: [String: String] = [:]
+    ) throws {
+        var headers = additionalHeaders
+        headers["Content-Type"] = "application/json"
+        try self.init(
+            path: path,
+            method: method,
+            queryItems: queryItems,
+            body: encoder.encode(jsonBody),
+            additionalHeaders: headers
+        )
+    }
+}
+
+// MARK: - URLRequest construction
+
+extension APIRequest {
+    /// Builds a `URLRequest` by appending `path` to `baseURL` and applying all fields.
+    ///
+    /// - Throws: `APIError.badURL` if the resulting URL cannot be constructed.
+    func urlRequest(baseURL: URL) throws -> URLRequest {
+        guard var components = URLComponents(
+            url: baseURL.appendingPathComponent(path),
+            resolvingAgainstBaseURL: true
+        ) else {
+            throw APIError.badURL
+        }
+
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+
+        guard let url = components.url else {
+            throw APIError.badURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        request.httpBody = body
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        for (key, value) in additionalHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+
+        return request
+    }
+}


### PR DESCRIPTION
## Summary

- Creates `Cove/Networking/` directory (auto-discovered by Xcode via `PBXFileSystemSynchronizedRootGroup`)
- `APIClient` — `final class`, `@unchecked Sendable`, `send<T: Decodable>(_ request: APIRequest) async throws -> T` entry point; injects Firebase ID Token as `Authorization: Bearer` on every request; never blocks `@MainActor`
- `APIRequest` — value type expressing path, method, query items, and body; generic `init(jsonBody:)` convenience for JSON-encoded bodies
- `APIError` — 5 typed error cases (`unauthenticated`, `httpError`, `decodingError`, `networkError`, `badURL`); initial set for Phase 0, expanded in #223
- Private `TokenCache` actor with 50-second TTL; wraps `getIDTokenResult(forcingRefresh:)` so all errors surface as `APIError`
- `#if DEBUG` request/response logging via `OSLog` (`com.danicajiao.cove / APIClient` category)
- `baseURL: URL` injected at init — env switching (staging vs. prod) deferred to #223

## Test plan

- [x] Build succeeds in Xcode (`Cmd+B`) — no missing module or type errors
- [x] In a DEBUG build, authenticated requests to `api.coveapp.dev/health` log `→ GET ...` and `← 200 ...` in the Console
- [x] Signing out and calling `APIClient.send` returns `APIError.unauthenticated`
- [x] `swiftformat .` and `swiftlint` report no violations (verified in CI)

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)