### PR TITLE
Define APIError types and APIEnvironment for env switching

### DIFF
--- a/apps/ios/Cove/Networking/APIClient.swift
+++ b/apps/ios/Cove/Networking/APIClient.swift
@@ -22,14 +22,16 @@ import OSLog
 /// let result: MyResponse = try await client.send(APIRequest(path: "health"))
 /// ```
 ///
-/// > Note: Environment switching (staging vs. prod base URLs) is handled in issue #223.
+/// > Note: Use the no-argument `init()` for standard use — it reads `APIEnvironment.current`
+/// > automatically. Pass an explicit `baseURL` only in tests or to force a specific environment.
 final class APIClient: @unchecked Sendable {
     // MARK: Properties
 
     /// The base URL prepended to every request path.
     ///
-    /// Inject a staging URL during testing; prod URL in release builds.
-    /// Issue #223 will provide convenience factory properties for both environments.
+    /// Set automatically from `APIEnvironment.current` by the no-argument convenience
+    /// initializer. Pass an explicit URL to override (e.g. in unit tests or to force
+    /// a specific environment).
     let baseURL: URL
 
     private let session: URLSession
@@ -37,6 +39,21 @@ final class APIClient: @unchecked Sendable {
     private let tokenCache = TokenCache()
 
     // MARK: Init
+
+    /// Creates a client pointed at `APIEnvironment.current.baseURL`.
+    ///
+    /// This is the standard initializer for production and debug use.
+    /// Pass an explicit `baseURL` to target a different environment (e.g. in tests).
+    convenience init(
+        session: URLSession = .shared,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.init(
+            baseURL: APIEnvironment.current.baseURL,
+            session: session,
+            decoder: decoder
+        )
+    }
 
     init(
         baseURL: URL,
@@ -56,10 +73,13 @@ final class APIClient: @unchecked Sendable {
     /// avoids redundant `getIDTokenResult` calls in burst scenarios while ensuring tokens
     /// stay fresh (Firebase rotates them hourly; our TTL is well within that window).
     ///
-    /// - Throws: `APIError.unauthenticated` when no user is signed in,
-    ///           `APIError.httpError` for non-2xx responses,
-    ///           `APIError.decodingError` when the body cannot be decoded into `T`,
-    ///           `APIError.networkError` for transport failures.
+    /// - Throws: `APIError.tokenUnavailable` when no user is signed in or the token fetch fails,
+    ///           `APIError.unauthorized` for HTTP 401,
+    ///           `APIError.forbidden` for HTTP 403,
+    ///           `APIError.notFound` for HTTP 404,
+    ///           `APIError.server` for 5xx and other unexpected status codes,
+    ///           `APIError.transport` for network-level failures,
+    ///           `APIError.decoding` when the body cannot be decoded into `T`.
     func send<T: Decodable>(_ request: APIRequest) async throws -> T {
         let token = try await tokenCache.validToken()
 
@@ -73,26 +93,43 @@ final class APIClient: @unchecked Sendable {
         let (data, response): (Data, URLResponse)
         do {
             (data, response) = try await session.data(for: urlRequest)
+        } catch let error as URLError {
+            throw APIError.transport(error)
         } catch {
-            throw APIError.networkError(error)
+            throw APIError.transport(URLError(.unknown))
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw APIError.networkError(URLError(.badServerResponse))
+            throw APIError.transport(URLError(.badServerResponse))
         }
 
         #if DEBUG
             APIClient.logResponse(httpResponse, data: data)
         #endif
 
-        guard (200 ..< 300).contains(httpResponse.statusCode) else {
-            throw APIError.httpError(statusCode: httpResponse.statusCode, data: data)
+        switch httpResponse.statusCode {
+        case 200 ..< 300:
+            break
+        case 401:
+            throw APIError.unauthorized
+        case 403:
+            throw APIError.forbidden
+        case 404:
+            throw APIError.notFound
+        default:
+            throw APIError.server(
+                statusCode: httpResponse.statusCode,
+                message: APIClient.errorMessage(from: data)
+            )
         }
 
         do {
             return try decoder.decode(T.self, from: data)
+        } catch let error as DecodingError {
+            throw APIError.decoding(error)
         } catch {
-            throw APIError.decodingError(error)
+            // JSONDecoder should always throw DecodingError; this branch is a safeguard.
+            throw APIError.server(statusCode: httpResponse.statusCode, message: error.localizedDescription)
         }
     }
 }
@@ -114,7 +151,7 @@ private actor TokenCache {
 
     func validToken() async throws -> String {
         guard let user = Auth.auth().currentUser else {
-            throw APIError.unauthenticated
+            throw APIError.tokenUnavailable
         }
 
         let now = Date()
@@ -127,9 +164,9 @@ private actor TokenCache {
         do {
             result = try await user.getIDTokenResult(forcingRefresh: false)
         } catch {
-            // #223 will add a dedicated .authError case; for now wrap as networkError
-            // so callers always receive an APIError.
-            throw APIError.networkError(error)
+            // Firebase SDK types are not exposed in APIError — any token fetch failure
+            // surfaces as .tokenUnavailable so callers stay decoupled from FirebaseAuth.
+            throw APIError.tokenUnavailable
         }
 
         cache[user.uid] = Entry(
@@ -137,6 +174,19 @@ private actor TokenCache {
             expiresAt: now.addingTimeInterval(Self.ttl)
         )
         return result.token
+    }
+}
+
+// MARK: - Response helpers
+
+private extension APIClient {
+    /// Attempts to extract a human-readable error message from a JSON response body.
+    /// Looks for top-level `"message"` or `"error"` string fields.
+    static func errorMessage(from data: Data) -> String? {
+        guard let json = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return nil
+        }
+        return json["message"] ?? json["error"]
     }
 }
 

--- a/apps/ios/Cove/Networking/APIEnvironment.swift
+++ b/apps/ios/Cove/Networking/APIEnvironment.swift
@@ -1,0 +1,60 @@
+//
+//  APIEnvironment.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/17/26.
+//
+
+import Foundation
+
+/// The backend environment the app points at.
+///
+/// ## Environment selection
+///
+/// `APIEnvironment.current` is resolved at runtime using a compile-time flag:
+/// - **Debug** builds default to `.staging`
+/// - **Release** builds default to `.production`
+///
+/// This was chosen over an Info.plist key because we don't yet have CI lanes that
+/// produce per-environment builds, so a simple `#if DEBUG` check covers all current
+/// cases without additional tooling. If QA ever needs to switch environments without
+/// a recompile, replace `current` with an Info.plist lookup and add a
+/// `API_BASE_URL` key to each scheme's Run configuration.
+///
+/// ## Staging URL
+///
+/// The staging URL below is a placeholder — confirm the actual hostname when the
+/// staging Cloudflare Tunnel is provisioned in Phase 1.
+enum APIEnvironment {
+    case staging
+    case production
+
+    // MARK: - Base URL
+
+    var baseURL: URL {
+        switch self {
+        case .staging:
+            // Placeholder — confirm hostname when Phase 1 staging Cloudflare Tunnel is provisioned.
+            // Candidate: https://staging.api.coveapp.dev
+            // swiftlint:disable:next force_unwrapping
+            URL(string: "https://staging.api.coveapp.dev")!
+        case .production:
+            // swiftlint:disable:next force_unwrapping
+            URL(string: "https://api.coveapp.dev")!
+        }
+    }
+
+    // MARK: - Current environment
+
+    /// The environment used by `APIClient` when no explicit `baseURL` is injected.
+    ///
+    /// - Debug builds → `.staging`
+    /// - Release builds → `.production`
+    static var current: APIEnvironment {
+        #if DEBUG
+            return .staging
+        #else
+            return .production
+        #endif
+    }
+}

--- a/apps/ios/Cove/Networking/APIError.swift
+++ b/apps/ios/Cove/Networking/APIError.swift
@@ -9,32 +9,76 @@ import Foundation
 
 /// Typed errors surfaced by `APIClient`.
 ///
-/// > Note: This is the initial set for Phase 0. Issue #223 will expand these
-/// > with additional cases and a dedicated `.authError` for Firebase token failures.
+/// Every case maps to a distinct failure point in the request pipeline:
+///
+/// ```
+/// tokenUnavailable  — Firebase didn't yield an ID token (user not signed in, or auth error)
+/// unauthorized      — Gateway rejected the token (HTTP 401)
+/// forbidden         — User is authenticated but not allowed (HTTP 403)
+/// notFound          — Resource doesn't exist (HTTP 404)
+/// server            — 5xx or other unexpected status code
+/// transport         — Network-level failure before a response arrived
+/// decoding          — Response arrived but couldn't be parsed into the expected type
+/// badURL            — Path + baseURL produced an invalid URL (programming error)
+/// ```
+///
+/// Firebase SDK types are never exposed here. Token fetch failures surface as
+/// `.tokenUnavailable`; all transport errors are wrapped as `URLError`.
 enum APIError: Error {
-    /// No Firebase user is signed in — request cannot be authenticated.
-    case unauthenticated
-    /// The server returned a non-2xx status code.
-    case httpError(statusCode: Int, data: Data)
-    /// The response body could not be decoded into the expected type.
-    case decodingError(Error)
-    /// A transport-level error occurred (e.g. no network, TLS failure).
-    case networkError(Error)
-    /// A valid URL could not be constructed from the provided path and base URL.
+    /// Firebase Auth did not return an ID token.
+    /// Either no user is signed in, or the token fetch itself failed.
+    case tokenUnavailable
+
+    /// The gateway rejected the request — Firebase token invalid or expired (HTTP 401).
+    case unauthorized
+
+    /// The user is authenticated but not permitted to access this resource (HTTP 403).
+    case forbidden
+
+    /// The requested resource does not exist (HTTP 404).
+    case notFound
+
+    /// An unexpected status code was returned.
+    /// Covers 5xx server errors and any 4xx not handled by a specific case above.
+    /// `message` is parsed from the response body's `"message"` or `"error"` field when present.
+    case server(statusCode: Int, message: String?)
+
+    /// A transport-level failure occurred before a response arrived
+    /// (e.g. no network connection, TLS failure, request timeout).
+    case transport(URLError)
+
+    /// The response arrived but could not be decoded into the expected Swift type.
+    case decoding(DecodingError)
+
+    /// A valid URL could not be constructed from the request's path and base URL.
+    /// This is a programming error — check that `path` doesn't start with a leading slash
+    /// and that `baseURL` is well-formed.
     case badURL
 }
+
+// MARK: - LocalizedError
 
 extension APIError: LocalizedError {
     var errorDescription: String? {
         switch self {
-        case .unauthenticated:
-            "No authenticated user — sign in before making requests."
-        case let .httpError(statusCode, _):
-            "Server returned HTTP \(statusCode)."
-        case let .decodingError(error):
-            "Failed to decode response: \(error.localizedDescription)"
-        case let .networkError(error):
+        case .tokenUnavailable:
+            "Could not obtain a Firebase ID Token — make sure the user is signed in."
+        case .unauthorized:
+            "Authentication failed (HTTP 401) — token may be invalid or expired."
+        case .forbidden:
+            "Access denied (HTTP 403) — you don't have permission to perform this action."
+        case .notFound:
+            "The requested resource was not found (HTTP 404)."
+        case let .server(statusCode, message):
+            if let message {
+                "Server error (HTTP \(statusCode)): \(message)"
+            } else {
+                "Server error (HTTP \(statusCode))."
+            }
+        case let .transport(error):
             "Network error: \(error.localizedDescription)"
+        case let .decoding(error):
+            "Failed to decode server response: \(error.localizedDescription)"
         case .badURL:
             "Could not construct a valid URL for the request."
         }


### PR DESCRIPTION
## Summary

- **`APIError`** — expanded from the Phase 0 stub into a full typed error model:
  - `.tokenUnavailable` — Firebase didn't yield an ID token (replaces `.unauthenticated`)
  - `.unauthorized` — HTTP 401 (gateway rejected token)
  - `.forbidden` — HTTP 403
  - `.notFound` — HTTP 404
  - `.server(statusCode:message:)` — 5xx and any unhandled status; `message` parsed from JSON body `"message"` / `"error"` fields
  - `.transport(URLError)` — network-level failure (replaces `.networkError(Error)`)
  - `.decoding(DecodingError)` — response body couldn't be decoded (replaces `.decodingError(Error)`)
  - `.badURL` — kept from #222
  - Firebase SDK types are never exposed — all token failures surface as `.tokenUnavailable`

- **`APIEnvironment`** — new enum with `.staging` and `.production` cases, each carrying a `baseURL`
  - `APIEnvironment.current` resolves via `#if DEBUG` (Debug → staging, Release → production)
  - Staging URL is a placeholder (`https://staging.api.coveapp.dev`) — confirm when Phase 1 infra is provisioned
  - Choice of compile-time flag over Info.plist key documented in code comments

- **`APIClient`** — wired to new types:
  - Added no-argument `convenience init()` that reads `APIEnvironment.current.baseURL` automatically
  - `send` maps status codes to specific `APIError` cases via a `switch`
  - Transport errors cast to `URLError` before wrapping
  - Decoding failures cast to `DecodingError`
  - Added `errorMessage(from:)` helper to extract server error messages from JSON bodies

## Test plan

- [ ] Build succeeds in Xcode (`Cmd+B`)
- [ ] Debug build: `APIEnvironment.current` returns `.staging`
- [ ] Release build (Product → Archive or change scheme to Release): `APIEnvironment.current` returns `.production`
- [ ] Signing out and calling `send` surfaces `.tokenUnavailable` in the Xcode console
- [ ] `swiftformat .` and `swiftlint` report no violations (verified locally)

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)