### PR TITLE
Add repository protocols: ProductRepository, ImageRepository, UserRepository, FavoritesRepository

### DIFF
--- a/apps/ios/Cove/Models/UserProfile.swift
+++ b/apps/ios/Cove/Models/UserProfile.swift
@@ -1,0 +1,32 @@
+//
+//  UserProfile.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import Foundation
+
+/// A user's persisted profile record.
+///
+/// Distinct from Firebase Auth's `User` object, which is the authentication identity.
+/// `UserProfile` is the app-layer record stored in the backend (Firestore in Phase 0,
+/// `cove-user` in Phase 3) and may carry additional fields that Firebase Auth does not own.
+///
+/// The `id` field is the Firebase Auth UID and serves as the primary key in the backend.
+struct UserProfile: Codable, Identifiable {
+    /// The Firebase Auth UID. Primary key in the backend.
+    var id: String
+
+    /// The user's display name, if set.
+    var displayName: String?
+
+    /// The user's email address.
+    var email: String?
+
+    /// URL of the user's profile photo, if set.
+    var photoURL: URL?
+
+    /// When the profile record was first created.
+    var createdAt: Date?
+}

--- a/apps/ios/Cove/Networking/Repositories/FavoritesRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/FavoritesRepository.swift
@@ -1,0 +1,49 @@
+//
+//  FavoritesRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import Foundation
+
+/// Abstraction over favorites list persistence.
+///
+/// This protocol handles only the durable read/write operations.
+/// Optimistic UI updates (toggling the heart icon before the write completes)
+/// remain the responsibility of `FavoritesStore`, which coordinates between
+/// in-memory state and this repository.
+///
+/// **Ordering:** `listFavorites(uid:)` returns items in insertion order
+/// (most recently favorited last). Implementations should preserve this order
+/// where the backing store allows it.
+protocol FavoritesRepository {
+    /// Returns all favorited product references for the given user.
+    ///
+    /// Returns an empty array when the user has no favorites — never throws
+    /// for an empty list.
+    ///
+    /// - Parameter uid: The Firebase Auth UID of the user whose favorites to fetch.
+    func listFavorites(uid: String) async throws -> [FavoriteProduct]
+
+    /// Records a product as a favourite for the given user.
+    ///
+    /// Implementations should be idempotent — calling `add` for an already-favorited
+    /// product should succeed without creating a duplicate record.
+    ///
+    /// - Parameters:
+    ///   - productId: The ID of the product to favourite.
+    ///   - categoryId: The category the product belongs to (required for hydration queries).
+    ///   - uid: The Firebase Auth UID of the user favouriting the product.
+    func add(productId: String, categoryId: String, uid: String) async throws
+
+    /// Removes a product from the given user's favourites.
+    ///
+    /// Implementations should be idempotent — calling `remove` for a product that is
+    /// not currently favourited should succeed silently.
+    ///
+    /// - Parameters:
+    ///   - productId: The ID of the product to un-favourite.
+    ///   - uid: The Firebase Auth UID of the user un-favouriting the product.
+    func remove(productId: String, uid: String) async throws
+}

--- a/apps/ios/Cove/Networking/Repositories/ImageRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/ImageRepository.swift
@@ -1,0 +1,26 @@
+//
+//  ImageRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import Foundation
+
+/// Abstraction over product image resolution.
+///
+/// Returns a `URL` the caller can hand directly to `AsyncImage` or use to
+/// fetch raw data. Implementations decide whether the URL points to a
+/// Firebase Storage download link, a cove-image endpoint, or a local asset.
+///
+/// **Caching:** Implementations are not required to cache URLs. If caching
+/// is needed, wrap the repository or handle it at the view layer via `AsyncImage`.
+protocol ImageRepository {
+    /// Returns a URL for the default image of the product with the given ID.
+    ///
+    /// - Parameter productId: The unique product identifier whose image is needed.
+    /// - Returns: A `URL` suitable for passing to `AsyncImage(url:)`.
+    /// - Throws: `APIError.notFound` when no image is registered for `productId`,
+    ///   or a transport/auth error if the URL must be fetched from a remote source.
+    func imageURL(for productId: String) async throws -> URL
+}

--- a/apps/ios/Cove/Networking/Repositories/ProductRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/ProductRepository.swift
@@ -1,0 +1,55 @@
+//
+//  ProductRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import Foundation
+
+/// Abstraction over all product-catalogue reads.
+///
+/// ViewModels depend on this protocol rather than on a specific data source.
+/// Swap the injected implementation (Firebase, CoveAPI, mock) without touching any ViewModel.
+///
+/// **Ordering:** `fetchHome()` and `fetchProducts(inCategories:)` return results in
+/// insertion order as determined by the backing store. No stable sort is guaranteed
+/// across implementations.
+///
+/// **Polymorphism:** All methods that return `[any Product]` or `any Product` may
+/// return any concrete type conforming to `Product` (e.g. `CoffeeProduct`, `MusicProduct`,
+/// `ApparelProduct`). Callers should use `is` / `as?` casts or the `categoryId` field
+/// to dispatch to the correct concrete type.
+protocol ProductRepository {
+    /// Fetches the full product catalogue for the home feed.
+    func fetchHome() async throws -> [any Product]
+
+    /// Fetches a single product by its unique ID.
+    ///
+    /// - Throws: `APIError.notFound` (or an equivalent domain error) when no product
+    ///   exists for the given ID.
+    func fetchProduct(id: String) async throws -> any Product
+
+    /// Fetches the type-specific detail document for a product.
+    ///
+    /// The returned `ProductDetails` concrete type is determined by the product's
+    /// `categoryId` — callers cast to `CoffeeProductDetails`, `MusicProductDetails`,
+    /// or `ApparelProductDetails` as needed.
+    func fetchDetails(for product: any Product) async throws -> any ProductDetails
+
+    /// Fetches products in the same category as `categoryId`, capped at `limit` results.
+    ///
+    /// Used by `ProductDetailViewModel` to populate the "similar products" shelf.
+    /// Results may include the source product itself — callers are responsible for
+    /// filtering it out if needed.
+    func fetchSimilarProducts(categoryId: String, limit: Int) async throws -> [any Product]
+
+    /// Fetches products whose `categoryId` is in the provided set.
+    ///
+    /// Used by `BagViewModel` to populate the "you might also like" shelf alongside
+    /// bag items. Implementations may cap the result set internally.
+    func fetchProducts(inCategories categoryIds: [String]) async throws -> [any Product]
+
+    /// Fetches all brands.
+    func fetchBrands() async throws -> [Brand]
+}

--- a/apps/ios/Cove/Networking/Repositories/UserRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/UserRepository.swift
@@ -1,0 +1,32 @@
+//
+//  UserRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import Foundation
+
+/// Abstraction over user profile reads and writes.
+///
+/// **Lazy-create semantics:** `fetchProfile(uid:)` implementations are expected to
+/// create a default profile record on first access if one does not yet exist.
+/// Callers may always `await fetchProfile` and treat the result as non-nil.
+protocol UserRepository {
+    /// Fetches the profile for the given Firebase UID.
+    ///
+    /// If no profile record exists yet (e.g. first sign-in), implementations
+    /// should create and return a default profile rather than throwing.
+    ///
+    /// - Parameter uid: The Firebase Auth UID of the user whose profile to fetch.
+    func fetchProfile(uid: String) async throws -> UserProfile
+
+    /// Persists changes to an existing user profile.
+    ///
+    /// The `profile.id` field must match an existing record. Implementations
+    /// should perform a partial update (merge) rather than a full overwrite so
+    /// that concurrent writes to different fields do not conflict.
+    ///
+    /// - Parameter profile: The updated profile to persist.
+    func updateProfile(_ profile: UserProfile) async throws
+}


### PR DESCRIPTION
## Summary
- Adds `Cove/Networking/Repositories/` with four protocol files: `ProductRepository`, `ImageRepository`, `UserRepository`, `FavoritesRepository`
- Adds `UserProfile` model to `Cove/Models/` (required by `UserRepository`)
- Protocols only — no implementations; Firebase implementations land in #225

## Protocol overview

| Protocol | Operations |
|---|---|
| `ProductRepository` | `fetchHome`, `fetchProduct(id:)`, `fetchDetails(for:)`, `fetchSimilarProducts(categoryId:limit:)`, `fetchProducts(inCategories:)`, `fetchBrands` |
| `ImageRepository` | `imageURL(for:)` — returns a `URL` for `AsyncImage` consumption |
| `UserRepository` | `fetchProfile(uid:)` (lazy-create semantics), `updateProfile(_:)` |
| `FavoritesRepository` | `listFavorites(uid:)`, `add(productId:categoryId:uid:)`, `remove(productId:uid:)` |

## Test plan
- [x] Project builds green in Xcode
- [x] `swiftformat .` reports 0 files reformatted
- [x] `swiftlint` reports 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)