### PR TITLE
Lift Firestore code into Firebase*Repository implementations

### DIFF
--- a/apps/ios/Cove/Models/FavoritesStore.swift
+++ b/apps/ios/Cove/Models/FavoritesStore.swift
@@ -6,16 +6,23 @@
 //
 
 import FirebaseAuth
-import FirebaseFirestore
 
+/// Global store that tracks which products the signed-in user has favourited.
+///
+/// `FavoritesStore` owns the in-memory `favoriteIds` set and handles optimistic
+/// UI updates (toggling the heart before the write completes). Durable reads and
+/// writes are delegated to a `FavoritesRepository` so the backing store can be
+/// swapped (Firebase → `cove-user` in Phase 3) without touching this class.
 @MainActor
 class FavoritesStore: ObservableObject {
     @Published private(set) var favoriteIds: Set<String> = []
     @Published private(set) var isTogglingFavorite: Bool = false
 
     private var authListener: AuthStateDidChangeListenerHandle?
+    private let repository: FavoritesRepository
 
-    init() {
+    init(repository: FavoritesRepository = FirebaseFavoritesRepository()) {
+        self.repository = repository
         authListener = Auth.auth().addStateDidChangeListener { [weak self] _, user in
             Task { @MainActor in
                 if user != nil {
@@ -39,11 +46,9 @@ class FavoritesStore: ObservableObject {
 
     func loadFavorites() async {
         guard let user = Auth.auth().currentUser else { return }
-        let firestore = Firestore.firestore()
         do {
-            let snapshot = try await firestore.collection("users").document(user.uid).collection("favorites").getDocuments()
-            let ids = snapshot.documents.compactMap { try? $0.data(as: FavoriteProduct.self).productId }
-            favoriteIds = Set(ids)
+            let favorites = try await repository.listFavorites(uid: user.uid)
+            favoriteIds = Set(favorites.map(\.productId))
         } catch {
             print("Error loading favorites: \(error)")
         }
@@ -67,17 +72,11 @@ class FavoritesStore: ObservableObject {
             favoriteIds.insert(productId)
         }
 
-        let favoritesRef = Firestore.firestore()
-            .collection("users").document(user.uid).collection("favorites")
-
         do {
             if wasFavorite {
-                let snapshot = try await favoritesRef.whereField("productId", isEqualTo: productId).getDocuments()
-                for document in snapshot.documents {
-                    try await document.reference.delete()
-                }
+                try await repository.remove(productId: productId, uid: user.uid)
             } else {
-                try favoritesRef.addDocument(from: FavoriteProduct(productId: productId, categoryId: categoryId))
+                try await repository.add(productId: productId, categoryId: categoryId, uid: user.uid)
             }
         } catch {
             print("Error toggling favorite: \(error)")

--- a/apps/ios/Cove/Networking/Repositories/Firebase/FirebaseFavoritesRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/Firebase/FirebaseFavoritesRepository.swift
@@ -1,0 +1,48 @@
+//
+//  FirebaseFavoritesRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import FirebaseFirestore
+
+/// Firestore-backed implementation of `FavoritesRepository`.
+///
+/// Reads and writes the `users/{uid}/favorites` subcollection. The logic
+/// previously embedded in `FavoritesStore` is lifted here verbatim so
+/// `FavoritesStore` can delegate to this repository instead of calling
+/// Firestore directly.
+final class FirebaseFavoritesRepository: FavoritesRepository {
+    // MARK: - Properties
+
+    private let firestore = Firestore.firestore()
+
+    // MARK: - FavoritesRepository
+
+    func listFavorites(uid: String) async throws -> [FavoriteProduct] {
+        let snapshot = try await favoritesCollection(uid: uid).getDocuments()
+        return snapshot.documents.compactMap { try? $0.data(as: FavoriteProduct.self) }
+    }
+
+    func add(productId: String, categoryId: String, uid: String) async throws {
+        try favoritesCollection(uid: uid)
+            .addDocument(from: FavoriteProduct(productId: productId, categoryId: categoryId))
+    }
+
+    func remove(productId: String, uid: String) async throws {
+        let snapshot = try await favoritesCollection(uid: uid)
+            .whereField("productId", isEqualTo: productId)
+            .getDocuments()
+
+        for document in snapshot.documents {
+            try await document.reference.delete()
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func favoritesCollection(uid: String) -> CollectionReference {
+        firestore.collection("users").document(uid).collection("favorites")
+    }
+}

--- a/apps/ios/Cove/Networking/Repositories/Firebase/FirebaseImageRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/Firebase/FirebaseImageRepository.swift
@@ -1,0 +1,40 @@
+//
+//  FirebaseImageRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import FirebaseFirestore
+import FirebaseStorage
+
+/// Firebase Storage-backed implementation of `ImageRepository`.
+///
+/// Fetches the product's `defaultImageURL` from Firestore, then resolves
+/// it to a fresh HTTPS download URL via Firebase Storage. In Phase 2 this
+/// implementation is replaced by `CoveAPIImageRepository`, which calls
+/// `cove-image` directly and avoids the double round-trip.
+final class FirebaseImageRepository: ImageRepository {
+    // MARK: - Properties
+
+    private let firestore = Firestore.firestore()
+    private let storage = Storage.storage()
+
+    // MARK: - ImageRepository
+
+    func imageURL(for productId: String) async throws -> URL {
+        let snapshot = try await firestore
+            .collection("products")
+            .document(productId)
+            .getDocument()
+
+        guard snapshot.exists,
+              let urlString = snapshot["defaultImageURL"] as? String
+        else {
+            throw APIError.notFound
+        }
+
+        let ref = storage.reference(forURL: urlString)
+        return try await ref.downloadURL()
+    }
+}

--- a/apps/ios/Cove/Networking/Repositories/Firebase/FirebaseProductRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/Firebase/FirebaseProductRepository.swift
@@ -1,0 +1,111 @@
+//
+//  FirebaseProductRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import FirebaseFirestore
+
+/// Firestore-backed implementation of `ProductRepository`.
+///
+/// All Firestore reads that were previously scattered across `HomeViewModel`,
+/// `ProductDetailViewModel`, and `BagViewModel` are consolidated here.
+/// ViewModels should not import `FirebaseFirestore` directly after the
+/// DI refactor lands in #226.
+final class FirebaseProductRepository: ProductRepository {
+    // MARK: - Properties
+
+    private let firestore = Firestore.firestore()
+
+    // MARK: - ProductRepository
+
+    func fetchHome() async throws -> [any Product] {
+        let snapshot = try await firestore.collection("products").getDocuments()
+        return snapshot.documents.compactMap { decodeProduct(from: $0) }
+    }
+
+    func fetchProduct(id: String) async throws -> any Product {
+        let snapshot = try await firestore.collection("products").document(id).getDocument()
+
+        guard snapshot.exists else {
+            throw APIError.notFound
+        }
+
+        guard let product = decodeProduct(from: snapshot) else {
+            throw APIError.server(statusCode: 422, message: "Unrecognized product category for id \(id)")
+        }
+
+        return product
+    }
+
+    func fetchDetails(for product: any Product) async throws -> any ProductDetails {
+        let snapshot = try await firestore
+            .collection("product_details")
+            .document(product.productDetailsId)
+            .getDocument()
+
+        guard snapshot.exists else {
+            throw APIError.notFound
+        }
+
+        if product is CoffeeProduct {
+            return try snapshot.data(as: CoffeeProductDetails.self)
+        } else if product is MusicProduct {
+            return try snapshot.data(as: MusicProductDetails.self)
+        } else if product is ApparelProduct {
+            return try snapshot.data(as: ApparelProductDetails.self)
+        } else {
+            throw APIError.server(statusCode: 422, message: "Unrecognized product type — cannot decode details")
+        }
+    }
+
+    func fetchSimilarProducts(categoryId: String, limit: Int) async throws -> [any Product] {
+        let snapshot = try await firestore
+            .collection("products")
+            .whereField("categoryId", isEqualTo: categoryId)
+            .limit(to: limit)
+            .getDocuments()
+
+        return snapshot.documents.compactMap { decodeProduct(from: $0) }
+    }
+
+    func fetchProducts(inCategories categoryIds: [String]) async throws -> [any Product] {
+        guard !categoryIds.isEmpty else { return [] }
+
+        let snapshot = try await firestore
+            .collection("products")
+            .whereField("categoryId", in: categoryIds)
+            .getDocuments()
+
+        return snapshot.documents.compactMap { decodeProduct(from: $0) }
+    }
+
+    func fetchBrands() async throws -> [Brand] {
+        let snapshot = try await firestore.collection("brands").getDocuments()
+        return snapshot.documents.compactMap { try? $0.data(as: Brand.self) }
+    }
+
+    // MARK: - Private helpers
+
+    /// Decodes a Firestore document into the correct `Product` concrete type
+    /// based on its `categoryId` field. Returns `nil` for unrecognised categories.
+    private func decodeProduct(from snapshot: DocumentSnapshot) -> (any Product)? {
+        let categoryId = snapshot["categoryId"] as? String
+        do {
+            switch categoryId {
+            case ProductTypes.coffee.rawValue:
+                return try snapshot.data(as: CoffeeProduct.self)
+            case ProductTypes.music.rawValue:
+                return try snapshot.data(as: MusicProduct.self)
+            case ProductTypes.apparel.rawValue:
+                return try snapshot.data(as: ApparelProduct.self)
+            default:
+                return nil
+            }
+        } catch {
+            print("FirebaseProductRepository: failed to decode product \(snapshot.documentID): \(error)")
+            return nil
+        }
+    }
+}

--- a/apps/ios/Cove/Networking/Repositories/Firebase/FirebaseUserRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/Firebase/FirebaseUserRepository.swift
@@ -1,0 +1,70 @@
+//
+//  FirebaseUserRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import FirebaseAuth
+import FirebaseFirestore
+
+/// Firestore-backed implementation of `UserRepository`.
+///
+/// Stores user profile data in `users/{uid}` in Firestore.
+/// On first access, lazily creates a default profile record seeded from
+/// the Firebase Auth user object so callers never receive a missing-profile error.
+///
+/// `ProfileViewModel` currently reads profile data entirely from Firebase Auth.
+/// After the DI refactor in #226, it will depend on this repository instead,
+/// enabling the migration to `cove-user` in Phase 3 with no ViewModel changes.
+final class FirebaseUserRepository: UserRepository {
+    // MARK: - Properties
+
+    private let firestore = Firestore.firestore()
+
+    // MARK: - UserRepository
+
+    func fetchProfile(uid: String) async throws -> UserProfile {
+        let ref = firestore.collection("users").document(uid)
+        let snapshot = try await ref.getDocument()
+
+        if snapshot.exists, let data = snapshot.data() {
+            return UserProfile(
+                id: uid,
+                displayName: data["displayName"] as? String,
+                email: data["email"] as? String,
+                photoURL: (data["photoURL"] as? String).flatMap(URL.init(string:)),
+                createdAt: (data["createdAt"] as? Timestamp)?.dateValue()
+            )
+        }
+
+        // Lazy-create: seed a default profile from Firebase Auth and persist it.
+        let authUser = Auth.auth().currentUser
+        let profile = UserProfile(
+            id: uid,
+            displayName: authUser?.displayName,
+            email: authUser?.email,
+            photoURL: authUser?.photoURL,
+            createdAt: authUser?.metadata.creationDate
+        )
+
+        var fields: [String: Any] = [:]
+        if let displayName = profile.displayName { fields["displayName"] = displayName }
+        if let email = profile.email { fields["email"] = email }
+        if let photoURL = profile.photoURL { fields["photoURL"] = photoURL.absoluteString }
+        fields["createdAt"] = Timestamp(date: profile.createdAt ?? Date())
+
+        try await ref.setData(fields, merge: true)
+        return profile
+    }
+
+    func updateProfile(_ profile: UserProfile) async throws {
+        var fields: [String: Any] = [:]
+        if let displayName = profile.displayName { fields["displayName"] = displayName }
+        if let email = profile.email { fields["email"] = email }
+        if let photoURL = profile.photoURL { fields["photoURL"] = photoURL.absoluteString }
+        if let createdAt = profile.createdAt { fields["createdAt"] = Timestamp(date: createdAt) }
+
+        try await firestore.collection("users").document(profile.id).setData(fields, merge: true)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Cove/Networking/Repositories/Firebase/` with four concrete implementations conforming to the protocols from #224
- Updates `FavoritesStore` to delegate reads/writes to `FirebaseFavoritesRepository` — `import FirebaseFirestore` removed from `FavoritesStore`
- ViewModels are left untouched; DI wiring lands in #226

## What moved where

| Class | Source of lifted code |
|---|---|
| `FirebaseProductRepository` | `HomeViewModel`, `ProductDetailViewModel`, `BagViewModel` |
| `FirebaseImageRepository` | `ProductCardView` (Storage download → now returns a `URL` via `downloadURL()`) |
| `FirebaseUserRepository` | New (no existing Firestore profile code — seeds from Firebase Auth on first access) |
| `FirebaseFavoritesRepository` | `FavoritesStore.loadFavorites()` and `FavoritesStore.toggle()` |

## Behaviour change
None. `FavoritesStore` public API is identical. ViewModels still call Firestore directly until #226.

## Test plan
- [x] Project builds green in Xcode
- [x] Launch app, browse home feed — products load as before
- [x] Open product detail — details and similar products load
- [x] Favourite an item — heart toggles and persists across restart
- [x] View favourites tab — favourited products appear
- [x] `swiftformat .` reports 0 files reformatted
- [x] `swiftlint` reports 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)