### PR TITLE
Refactor ViewModels to depend on repository protocols via DI

### DIFF
--- a/apps/ios/Cove/Networking/Repositories/Firebase/FirebaseProductRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/Firebase/FirebaseProductRepository.swift
@@ -81,6 +81,24 @@ final class FirebaseProductRepository: ProductRepository {
         return snapshot.documents.compactMap { decodeProduct(from: $0) }
     }
 
+    func fetchProducts(withIds ids: [String]) async throws -> [any Product] {
+        guard !ids.isEmpty else { return [] }
+
+        var products: [any Product] = []
+
+        // Firestore's `in` operator supports up to 30 values — batch if needed.
+        for batchStart in stride(from: 0, to: ids.count, by: 30) {
+            let batch = Array(ids[batchStart ..< min(batchStart + 30, ids.count)])
+            let snapshot = try await firestore
+                .collection("products")
+                .whereField(FieldPath.documentID(), in: batch)
+                .getDocuments()
+            products.append(contentsOf: snapshot.documents.compactMap { decodeProduct(from: $0) })
+        }
+
+        return products
+    }
+
     func fetchBrands() async throws -> [Brand] {
         let snapshot = try await firestore.collection("brands").getDocuments()
         return snapshot.documents.compactMap { try? $0.data(as: Brand.self) }

--- a/apps/ios/Cove/Networking/Repositories/ProductRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/ProductRepository.swift
@@ -50,6 +50,13 @@ protocol ProductRepository {
     /// bag items. Implementations may cap the result set internally.
     func fetchProducts(inCategories categoryIds: [String]) async throws -> [any Product]
 
+    /// Fetches products whose document IDs are in the provided set.
+    ///
+    /// Used by `FavoritesViewModel` to hydrate the favourites list from persisted
+    /// product IDs. Implementations must batch queries when `ids` exceeds 30 elements
+    /// to stay within Firestore's `in` operator limit (or the equivalent backend limit).
+    func fetchProducts(withIds ids: [String]) async throws -> [any Product]
+
     /// Fetches all brands.
     func fetchBrands() async throws -> [Brand]
 }

--- a/apps/ios/Cove/View Models/BagViewModel.swift
+++ b/apps/ios/Cove/View Models/BagViewModel.swift
@@ -6,46 +6,24 @@
 //
 
 import FirebaseAuth
-import FirebaseFirestore
 
 class BagViewModel: ObservableObject {
     @Published var similarProducts = [any Product]()
     var tempCategories = [String]()
     var fetchedProductIds = [String]()
 
-    private func decodeProduct(from document: QueryDocumentSnapshot) -> (any Product)? {
-        let categoryId = document["categoryId"] as? String
-        do {
-            if categoryId == ProductTypes.coffee.rawValue {
-                return try document.data(as: CoffeeProduct.self)
-            } else if categoryId == ProductTypes.music.rawValue {
-                return try document.data(as: MusicProduct.self)
-            } else if categoryId == ProductTypes.apparel.rawValue {
-                return try document.data(as: ApparelProduct.self)
-            }
-        } catch {
-            print(error)
-        }
-        return nil
+    private let productRepository: ProductRepository
+    private let favoritesRepository: FavoritesRepository
+
+    init(
+        productRepository: ProductRepository = FirebaseProductRepository(),
+        favoritesRepository: FavoritesRepository = FirebaseFavoritesRepository()
+    ) {
+        self.productRepository = productRepository
+        self.favoritesRepository = favoritesRepository
     }
 
-    private func applyFavorites(to products: inout [any Product], snapshot: QuerySnapshot) throws {
-        for document in snapshot.documents {
-            do {
-                let favoriteProduct = try document.data(as: FavoriteProduct.self)
-                guard let index = products.firstIndex(where: { $0.id == favoriteProduct.productId }) else {
-                    print("Failed to get local index of favorite product")
-                    return
-                }
-                products[index].isFavorite = true
-            } catch {
-                print(error)
-                throw error
-            }
-        }
-    }
-
-    /// Fetches similar products from Firebase and populates the similarProducts array used in the HomeView
+    /// Fetches similar products and populates the similarProducts array used in BagView
     func fetchSimilarProducts(categories: [String]) async throws {
         if categories.isEmpty {
             await MainActor.run(body: { self.similarProducts = [] })
@@ -56,39 +34,31 @@ class BagViewModel: ObservableObject {
 
         print("Fetching similar products...")
         fetchedProductIds = [String]()
-        let firestore = Firestore.firestore()
 
-        do {
-            var snapshot = try await firestore.collection("products").whereField("categoryId", in: categories).getDocuments()
+        var products = try await productRepository.fetchProducts(inCategories: categories)
+        fetchedProductIds = products.compactMap(\.id)
 
-            var products: [any Product] = snapshot.documents.compactMap { document in
-                guard let product = decodeProduct(from: document) else { return nil }
-                fetchedProductIds.append(document.documentID)
-                return product
-            }
-
-            if products.isEmpty {
-                print("No products returned from request")
-                return
-            }
-
-            guard let user = Auth.auth().currentUser else {
-                print("Failed to get signed in user to fetch favorites")
-                return
-            }
-
-            snapshot = try await firestore.collection("users").document(user.uid).collection("favorites")
-                .whereField("productId", in: fetchedProductIds)
-                .getDocuments()
-
-            try applyFavorites(to: &products, snapshot: snapshot)
-
-            tempCategories = categories
-            let sendableProducts = products
-            await MainActor.run(body: { self.similarProducts = sendableProducts })
-        } catch {
-            print(error)
-            throw error
+        if products.isEmpty {
+            print("No products returned from request")
+            return
         }
+
+        guard let user = Auth.auth().currentUser else {
+            print("Failed to get signed in user to fetch favorites")
+            return
+        }
+
+        let favorites = try await favoritesRepository.listFavorites(uid: user.uid)
+        let favoriteIds = Set(favorites.map(\.productId))
+
+        for index in products.indices {
+            if let id = products[index].id, favoriteIds.contains(id) {
+                products[index].isFavorite = true
+            }
+        }
+
+        tempCategories = categories
+        let sendableProducts = products
+        await MainActor.run(body: { self.similarProducts = sendableProducts })
     }
 }

--- a/apps/ios/Cove/View Models/FavoritesViewModel.swift
+++ b/apps/ios/Cove/View Models/FavoritesViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import FirebaseAuth
-import FirebaseFirestore
 
 @MainActor
 class FavoritesViewModel: ObservableObject {
@@ -14,20 +13,15 @@ class FavoritesViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var favoriteCount: Int = 0
 
-    private func decodeProduct(from document: DocumentSnapshot) -> (any Product)? {
-        let categoryId = document["categoryId"] as? String
-        do {
-            if categoryId == ProductTypes.coffee.rawValue {
-                return try document.data(as: CoffeeProduct.self)
-            } else if categoryId == ProductTypes.music.rawValue {
-                return try document.data(as: MusicProduct.self)
-            } else if categoryId == ProductTypes.apparel.rawValue {
-                return try document.data(as: ApparelProduct.self)
-            }
-        } catch {
-            print(error)
-        }
-        return nil
+    private let favoritesRepository: FavoritesRepository
+    private let productRepository: ProductRepository
+
+    init(
+        favoritesRepository: FavoritesRepository = FirebaseFavoritesRepository(),
+        productRepository: ProductRepository = FirebaseProductRepository()
+    ) {
+        self.favoritesRepository = favoritesRepository
+        self.productRepository = productRepository
     }
 
     func fetchFavorites() async throws {
@@ -39,50 +33,17 @@ class FavoritesViewModel: ObservableObject {
         isLoading = true
         defer { isLoading = false }
 
-        let firestore = Firestore.firestore()
+        let favoriteRefs = try await favoritesRepository.listFavorites(uid: uid)
+        let productIds = favoriteRefs.map(\.productId)
 
-        do {
-            let favoritesSnapshot = try await firestore
-                .collection("users")
-                .document(uid)
-                .collection("favorites")
-                .getDocuments()
-
-            let productIds: [String] = favoritesSnapshot.documents.compactMap { document in
-                do {
-                    return try document.data(as: FavoriteProduct.self).productId
-                } catch {
-                    print(error)
-                    return nil
-                }
-            }
-
-            guard !productIds.isEmpty else {
-                favorites = []
-                favoriteCount = 0
-                return
-            }
-
-            var fetchedProducts: [any Product] = []
-
-            for batchStart in stride(from: 0, to: productIds.count, by: 30) {
-                let batchEnd = min(batchStart + 30, productIds.count)
-                let batch = Array(productIds[batchStart ..< batchEnd])
-
-                let productsSnapshot = try await firestore
-                    .collection("products")
-                    .whereField(FieldPath.documentID(), in: batch)
-                    .getDocuments()
-
-                let batchProducts: [any Product] = productsSnapshot.documents.compactMap { decodeProduct(from: $0) }
-                fetchedProducts.append(contentsOf: batchProducts)
-            }
-
-            favorites = fetchedProducts
-            favoriteCount = fetchedProducts.count
-        } catch {
-            print(error)
-            throw error
+        guard !productIds.isEmpty else {
+            favorites = []
+            favoriteCount = 0
+            return
         }
+
+        let fetchedProducts = try await productRepository.fetchProducts(withIds: productIds)
+        favorites = fetchedProducts
+        favoriteCount = fetchedProducts.count
     }
 }

--- a/apps/ios/Cove/View Models/HomeViewModel.swift
+++ b/apps/ios/Cove/View Models/HomeViewModel.swift
@@ -5,8 +5,7 @@
 //  Created by Daniel Cajiao on 12/6/22.
 //
 
-import FirebaseFirestore
-import FirebaseStorage
+import Foundation
 
 @MainActor
 class HomeViewModel: ObservableObject {
@@ -18,75 +17,39 @@ class HomeViewModel: ObservableObject {
 
     private var lastFetchTime: Date?
     private let cacheTimeout: TimeInterval = 300
+    private let productRepository: ProductRepository
 
-    private func decodeProduct(from document: QueryDocumentSnapshot) -> (any Product)? {
-        let categoryId = document["categoryId"] as? String
-        do {
-            if categoryId == ProductTypes.coffee.rawValue {
-                return try document.data(as: CoffeeProduct.self)
-            } else if categoryId == ProductTypes.music.rawValue {
-                return try document.data(as: MusicProduct.self)
-            } else if categoryId == ProductTypes.apparel.rawValue {
-                return try document.data(as: ApparelProduct.self)
-            }
-        } catch {
-            print(error)
-        }
-        return nil
+    init(productRepository: ProductRepository = FirebaseProductRepository()) {
+        self.productRepository = productRepository
     }
 
-    /// Fetches products from Firebase and populates the products array used in the HomeView
     func fetchProducts(forceRefresh: Bool = false) async throws {
         let cacheExpired = lastFetchTime.map { Date().timeIntervalSince($0) > cacheTimeout } ?? true
         guard products.isEmpty || forceRefresh || cacheExpired else { return }
 
         print("Fetching products...")
-        let firestore = Firestore.firestore()
+        let fetched = try await productRepository.fetchHome()
 
-        do {
-            let snapshot = try await firestore.collection("products").getDocuments()
-            let products: [any Product] = snapshot.documents.compactMap { decodeProduct(from: $0) }
-
-            if products.isEmpty {
-                print("No products returned from request")
-                return
-            }
-
-            self.products = products
-            lastFetchTime = Date()
-        } catch {
-            print(error)
-            throw error
+        if fetched.isEmpty {
+            print("No products returned from request")
+            return
         }
+
+        products = fetched
+        lastFetchTime = Date()
     }
 
     func fetchBrands() async throws {
         if !brands.isEmpty { return }
 
         print("Fetching brands...")
-        let firestore = Firestore.firestore()
+        let fetched = try await productRepository.fetchBrands()
 
-        do {
-            let snapshot = try await firestore.collection("brands").getDocuments()
-
-            let brands: [Brand] = snapshot.documents.compactMap { document in
-                do {
-                    return try document.data(as: Brand.self)
-                } catch {
-                    print(error)
-                    return nil
-                }
-            }
-
-            if brands.isEmpty {
-                print("No brands returned from request")
-                return
-            }
-
-            self.brands = brands
-        } catch {
-            print(error)
-            throw error
+        if fetched.isEmpty {
+            print("No brands returned from request")
+            return
         }
+
+        brands = fetched
     }
 }

--- a/apps/ios/Cove/View Models/ProductDetailViewModel.swift
+++ b/apps/ios/Cove/View Models/ProductDetailViewModel.swift
@@ -5,13 +5,15 @@
 //  Created by Daniel Cajiao on 4/9/23.
 //
 
-import FirebaseFirestore
+import Foundation
 
 class ProductDetailViewModel: ObservableObject {
     @Published var product: (any Product)?
     @Published var productDetails: ProductDetails?
     @Published var detailSelection: DetailSelection
     @Published var similarProducts: [any Product]
+
+    private let productRepository: ProductRepository
 
     enum DetailSelection {
         case description
@@ -22,7 +24,11 @@ class ProductDetailViewModel: ObservableObject {
         case tracklist
     }
 
-    init(productId: String) {
+    init(
+        productId: String,
+        productRepository: ProductRepository = FirebaseProductRepository()
+    ) {
+        self.productRepository = productRepository
         product = nil
         detailSelection = .description
         similarProducts = [any Product]()
@@ -42,91 +48,20 @@ class ProductDetailViewModel: ObservableObject {
 
     func fetchProduct(_ id: String) async {
         print("Fetching product with id: \(id)")
-        let firestore = Firestore.firestore()
-
         do {
-            let snapshot = try await firestore.collection("products").document(id).getDocument()
-
-            guard snapshot.exists else {
-                print("Product with id \(id) does not exist")
-                return
-            }
-
-            guard let categoryId = snapshot["categoryId"] as? String else {
-                print("Product document missing categoryId field")
-                return
-            }
-
-            if categoryId == ProductTypes.coffee.rawValue {
-                let coffeeProduct = try snapshot.data(as: CoffeeProduct.self)
-                await MainActor.run { self.product = coffeeProduct }
-            } else if categoryId == ProductTypes.music.rawValue {
-                let musicProduct = try snapshot.data(as: MusicProduct.self)
-                await MainActor.run { self.product = musicProduct }
-            } else if categoryId == ProductTypes.apparel.rawValue {
-                let apparelProduct = try snapshot.data(as: ApparelProduct.self)
-                await MainActor.run { self.product = apparelProduct }
-            } else {
-                print("Unknown product category: \(categoryId)")
-            }
+            let fetched = try await productRepository.fetchProduct(id: id)
+            await MainActor.run { self.product = fetched }
         } catch {
             print("Error fetching product: \(error)")
         }
     }
 
     func fetchProductDetails() async throws {
-        // Check if product have already been fetched
-        guard let product else {
-            return
-        }
+        guard let product else { return }
 
-        // Get a reference to Firestore
         print("Fetching product details...")
-        let firestore = Firestore.firestore()
-
-        do {
-            // Fetch 'product detail' document from the 'product_details' collection
-            let snapshot = try await firestore.collection("product_details").document(product.productDetailsId).getDocument()
-
-            if product is MusicProduct {
-                let productDetails = try snapshot.data(as: MusicProductDetails.self)
-
-                await MainActor.run(body: {
-                    self.productDetails = productDetails
-                })
-            } else if product is CoffeeProduct {
-                let productDetails = try snapshot.data(as: CoffeeProductDetails.self)
-
-                await MainActor.run(body: {
-                    self.productDetails = productDetails
-                })
-            } else if product is ApparelProduct {
-                let productDetails = try snapshot.data(as: ApparelProductDetails.self)
-
-                await MainActor.run(body: {
-                    self.productDetails = productDetails
-                })
-            }
-        } catch {
-            print(error)
-            throw error
-        }
-    }
-
-    private func decodeProduct(from document: QueryDocumentSnapshot) -> (any Product)? {
-        let categoryId = document["categoryId"] as? String
-        do {
-            if categoryId == ProductTypes.coffee.rawValue {
-                return try document.data(as: CoffeeProduct.self)
-            } else if categoryId == ProductTypes.music.rawValue {
-                return try document.data(as: MusicProduct.self)
-            } else if categoryId == ProductTypes.apparel.rawValue {
-                return try document.data(as: ApparelProduct.self)
-            }
-        } catch {
-            print(error)
-        }
-        return nil
+        let details = try await productRepository.fetchDetails(for: product)
+        await MainActor.run { self.productDetails = details }
     }
 
     func fetchSimilarProducts() async throws {
@@ -134,25 +69,13 @@ class ProductDetailViewModel: ObservableObject {
         guard let product else { return }
 
         print("Fetching similar products...")
-        let firestore = Firestore.firestore()
+        let fetched = try await productRepository.fetchSimilarProducts(categoryId: product.categoryId, limit: 5)
 
-        do {
-            let snapshot = try await firestore.collection("products")
-                .whereField("categoryId", isEqualTo: product.categoryId)
-                .limit(to: 5)
-                .getDocuments()
-
-            let products: [any Product] = snapshot.documents.compactMap { decodeProduct(from: $0) }
-
-            if products.isEmpty {
-                print("No products returned from request")
-                return
-            }
-
-            await MainActor.run { self.similarProducts = products }
-        } catch {
-            print(error)
-            throw error
+        if fetched.isEmpty {
+            print("No products returned from request")
+            return
         }
+
+        await MainActor.run { self.similarProducts = fetched }
     }
 }

--- a/apps/ios/Cove/View Models/ProfileViewModel.swift
+++ b/apps/ios/Cove/View Models/ProfileViewModel.swift
@@ -9,8 +9,14 @@ import FirebaseAuth
 
 @MainActor
 class ProfileViewModel: ObservableObject {
+    private let userRepository: UserRepository
+
     private var currentUser: User? {
         Auth.auth().currentUser
+    }
+
+    init(userRepository: UserRepository = FirebaseUserRepository()) {
+        self.userRepository = userRepository
     }
 
     var displayName: String {


### PR DESCRIPTION
## Summary
- All five ViewModels now accept repository dependencies via `init` with sensible Firebase defaults — existing `@StateObject` callsites are unchanged
- `FirebaseFirestore` and `FirebaseStorage` imports removed from every file in `Cove/View Models/`
- Also adds `fetchProducts(withIds:)` to `ProductRepository` (and implements it in `FirebaseProductRepository` with 30-item batching) — required by `FavoritesViewModel`

## Changes per ViewModel

| ViewModel | Injected | Removed |
|---|---|---|
| `HomeViewModel` | `ProductRepository` | `FirebaseFirestore`, `FirebaseStorage` |
| `ProductDetailViewModel` | `ProductRepository` | `FirebaseFirestore` |
| `BagViewModel` | `ProductRepository`, `FavoritesRepository` | `FirebaseFirestore` |
| `FavoritesViewModel` | `FavoritesRepository`, `ProductRepository` | `FirebaseFirestore` |
| `ProfileViewModel` | `UserRepository` | nothing (was already Auth-only) |

## Behaviour change
None. All `@StateObject` instantiation sites (`HomeView`, `BagView`, `FavoritesView`, `ProfileView`, `ProductDetailView`) use the no-argument form which picks up Firebase defaults automatically.

## Test plan
- [x] Project builds green in Xcode
- [x] Launch app, browse home feed — products load
- [x] Open product detail — details and similar products load
- [x] Favourite an item — heart toggles and persists across restart
- [x] View favourites tab — favourited products appear
- [x] Open bag with items — similar products shelf populates
- [x] View profile — name, initials, member date display correctly
- [x] `swiftformat .` reports 0 files reformatted
- [x] `swiftlint` reports 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)