### PR TITLE
Add CoveAPI*Repository stubs returning 501 not implemented

### DIFF
--- a/apps/ios/Cove/Networking/Repositories/CoveAPI/CoveAPIFavoritesRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/CoveAPI/CoveAPIFavoritesRepository.swift
@@ -1,0 +1,26 @@
+//
+//  CoveAPIFavoritesRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import Foundation
+
+/// Stub implementation of `FavoritesRepository` backed by `cove-api`.
+///
+/// Throws `APIError.server(statusCode: 501)` until Phase 3 fleshes it
+/// out with real `CoveUserClient` calls (favorites live under the user service).
+final class CoveAPIFavoritesRepository: FavoritesRepository {
+    func listFavorites(uid: String) async throws -> [FavoriteProduct] {
+        throw APIError.server(statusCode: 501, message: "listFavorites not implemented in Phase 0")
+    }
+
+    func add(productId: String, categoryId: String, uid: String) async throws {
+        throw APIError.server(statusCode: 501, message: "add not implemented in Phase 0")
+    }
+
+    func remove(productId: String, uid: String) async throws {
+        throw APIError.server(statusCode: 501, message: "remove not implemented in Phase 0")
+    }
+}

--- a/apps/ios/Cove/Networking/Repositories/CoveAPI/CoveAPIImageRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/CoveAPI/CoveAPIImageRepository.swift
@@ -1,0 +1,18 @@
+//
+//  CoveAPIImageRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import Foundation
+
+/// Stub implementation of `ImageRepository` backed by `cove-api`.
+///
+/// Throws `APIError.server(statusCode: 501)` until Phase 2 fleshes it
+/// out with real `CoveImageClient` calls.
+final class CoveAPIImageRepository: ImageRepository {
+    func imageURL(for productId: String) async throws -> URL {
+        throw APIError.server(statusCode: 501, message: "imageURL not implemented in Phase 0")
+    }
+}

--- a/apps/ios/Cove/Networking/Repositories/CoveAPI/CoveAPIProductRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/CoveAPI/CoveAPIProductRepository.swift
@@ -1,0 +1,44 @@
+//
+//  CoveAPIProductRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import Foundation
+
+/// Stub implementation of `ProductRepository` backed by `cove-api`.
+///
+/// Every method throws `APIError.server(statusCode: 501)` — this class is
+/// dormant until Phase 3 fleshes it out with real `CoveProductClient` calls.
+/// Wiring it in place now means the Phase 3 swap requires only a one-line
+/// DI change in `AppState`.
+final class CoveAPIProductRepository: ProductRepository {
+    func fetchHome() async throws -> [any Product] {
+        throw APIError.server(statusCode: 501, message: "fetchHome not implemented in Phase 0")
+    }
+
+    func fetchProduct(id: String) async throws -> any Product {
+        throw APIError.server(statusCode: 501, message: "fetchProduct not implemented in Phase 0")
+    }
+
+    func fetchDetails(for product: any Product) async throws -> any ProductDetails {
+        throw APIError.server(statusCode: 501, message: "fetchDetails not implemented in Phase 0")
+    }
+
+    func fetchSimilarProducts(categoryId: String, limit: Int) async throws -> [any Product] {
+        throw APIError.server(statusCode: 501, message: "fetchSimilarProducts not implemented in Phase 0")
+    }
+
+    func fetchProducts(inCategories categoryIds: [String]) async throws -> [any Product] {
+        throw APIError.server(statusCode: 501, message: "fetchProducts(inCategories:) not implemented in Phase 0")
+    }
+
+    func fetchProducts(withIds ids: [String]) async throws -> [any Product] {
+        throw APIError.server(statusCode: 501, message: "fetchProducts(withIds:) not implemented in Phase 0")
+    }
+
+    func fetchBrands() async throws -> [Brand] {
+        throw APIError.server(statusCode: 501, message: "fetchBrands not implemented in Phase 0")
+    }
+}

--- a/apps/ios/Cove/Networking/Repositories/CoveAPI/CoveAPIUserRepository.swift
+++ b/apps/ios/Cove/Networking/Repositories/CoveAPI/CoveAPIUserRepository.swift
@@ -1,0 +1,22 @@
+//
+//  CoveAPIUserRepository.swift
+//  Cove
+//
+//  Created by Daniel Cajiao on 5/18/26.
+//
+
+import Foundation
+
+/// Stub implementation of `UserRepository` backed by `cove-api`.
+///
+/// Throws `APIError.server(statusCode: 501)` until Phase 3 fleshes it
+/// out with real `CoveUserClient` calls.
+final class CoveAPIUserRepository: UserRepository {
+    func fetchProfile(uid: String) async throws -> UserProfile {
+        throw APIError.server(statusCode: 501, message: "fetchProfile not implemented in Phase 0")
+    }
+
+    func updateProfile(_ profile: UserProfile) async throws {
+        throw APIError.server(statusCode: 501, message: "updateProfile not implemented in Phase 0")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Cove/Networking/Repositories/CoveAPI/` with four stub classes conforming to the protocols from #224
- Every method throws `APIError.server(statusCode: 501, message: "<method> not implemented in Phase 0")`
- App wiring is unchanged — Firebase implementations remain the defaults; Phase 2/3 swaps these in service-by-service

## Stub inventory

| Class | Protocol | Activated in |
|---|---|---|
| `CoveAPIProductRepository` | `ProductRepository` | Phase 3 (#262) |
| `CoveAPIImageRepository` | `ImageRepository` | Phase 2 (#246) |
| `CoveAPIUserRepository` | `UserRepository` | Phase 3 (#262) |
| `CoveAPIFavoritesRepository` | `FavoritesRepository` | Phase 3 (#262) |

## Test plan
- [x] Project builds green in Xcode
- [x] App launches and behaves identically (Firebase implementations still wired)
- [x] `swiftformat .` reports 0 files reformatted
- [x] `swiftlint` reports 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)