### PR TITLE
Add monorepo build infrastructure: Dockerfile, Makefile, services CI

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -1,0 +1,74 @@
+name: CI - Services (Go)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/cove-api/**'
+      - '.github/workflows/services-ci.yml'
+  pull_request:
+    paths:
+      - 'apps/cove-api/**'
+      - '.github/workflows/services-ci.yml'
+
+jobs:
+  # ── cove-api ──────────────────────────────────────────────────────────────
+  cove-api:
+    name: cove-api
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write   # Required for Workload Identity Federation
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/cove-api/go.mod
+          cache-dependency-path: apps/cove-api/go.sum
+
+      - name: Run tests
+        working-directory: apps/cove-api
+        run: go test ./...
+
+      - name: Run vet
+        working-directory: apps/cove-api
+        run: go vet ./...
+
+      # Authenticate to GCP using Workload Identity Federation.
+      # Only runs on pushes to main (not PRs) since only main pushes
+      # need to push images to Artifact Registry.
+      - name: Authenticate to Google Cloud
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for Artifact Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Build and push image (main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/cove-api
+          push: true
+          tags: us-central1-docker.pkg.dev/cove/services/cove-api:sha-${{ github.sha }}
+          build-args: COMMIT_SHA=${{ github.sha }}
+
+      # On PRs: build only (no push) to verify the Dockerfile and that the
+      # service still compiles. The image is not tagged or stored.
+      - name: Build image (PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/cove-api
+          push: false
+          build-args: COMMIT_SHA=${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+# Cove monorepo — local build targets
+#
+# These targets are for local development only. CI uses Docker and GitHub
+# Actions directly. Run `make help` to see available targets.
+
+COMMIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo dev)
+
+# ── Docker image targets ────────────────────────────────────────────────────
+
+.PHONY: build-cove-api
+build-cove-api: ## Build the cove-api Docker image
+	docker build \
+		--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+		-t cove-api:$(COMMIT_SHA) \
+		apps/cove-api/
+
+.PHONY: build-all
+build-all: build-cove-api ## Build Docker images for all services
+
+# ── Go tooling ──────────────────────────────────────────────────────────────
+
+.PHONY: lint
+lint: ## Run linters for all services
+	cd apps/cove-api && go vet ./...
+
+.PHONY: test
+test: ## Run tests for all services
+	cd apps/cove-api && go test ./...
+
+# ── Help ────────────────────────────────────────────────────────────────────
+
+.PHONY: help
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/apps/cove-api/Dockerfile
+++ b/apps/cove-api/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1 — Build
+# Compiles the Go binary inside a full Go toolchain image.
+# Nothing from this stage ships in the final image.
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /build
+
+# Download dependencies first so this layer is cached between builds
+# that only change source files.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# COMMIT_SHA is injected by CI via --build-arg so the /health endpoint
+# can report the exact Git commit that is running.
+ARG COMMIT_SHA=dev
+
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags "-X main.commitSHA=${COMMIT_SHA}" \
+    -o cove-api \
+    ./cmd/api/
+
+# Stage 2 — Run
+# Distroless has no shell, no package manager, and no OS tools —
+# only the binary and the C library it needs. Attack surface is minimal.
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=builder /build/cove-api /cove-api
+
+EXPOSE 8080
+
+ENTRYPOINT ["/cove-api"]

--- a/docs/BACKEND_INFRASTRUCTURE.md
+++ b/docs/BACKEND_INFRASTRUCTURE.md
@@ -157,6 +157,90 @@ In Kubernetes, each service runs as a `Deployment` in `cove-staging` or `cove-pr
 
 ---
 
+## GitHub Actions → GCP authentication (Workload Identity Federation)
+
+GitHub Actions workflows that push container images to Artifact Registry authenticate to GCP using **Workload Identity Federation (WIF)** — no long-lived service account JSON key is stored anywhere.
+
+### How it works
+
+Instead of a key file, GCP trusts GitHub's identity provider directly. When a workflow job starts, GitHub issues it a signed JWT proving "I am a job in repo `danicajiao/cove`, on branch `main`". GCP verifies that signature against GitHub's public OIDC endpoint and exchanges it for a short-lived access token (1 hour). When the job ends the token is already expired — nothing to rotate or leak.
+
+```
+GitHub Actions job
+    │  OIDC token: "repo:danicajiao/cove, ref:refs/heads/main"
+    │  signed by GitHub's identity provider
+    ▼
+GCP Workload Identity Federation
+    │  verifies signature + checks attribute conditions
+    │  (only danicajiao/cove on main can impersonate this SA)
+    ▼
+Short-lived GCP access token (expires in 1 hour)
+    │
+    ▼
+Artifact Registry push (us-central1-docker.pkg.dev/cove/services/*)
+```
+
+### One-time GCP setup
+
+Run these commands once in your terminal (requires `gcloud` CLI authenticated as a project owner):
+
+```bash
+PROJECT_ID="cove-6a685"
+PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
+POOL_ID="github-actions"
+PROVIDER_ID="github"
+SA_NAME="github-actions-ci"
+REPO="danicajiao/cove"
+
+# 1. Create the Workload Identity Pool
+gcloud iam workload-identity-pools create $POOL_ID \
+  --project=$PROJECT_ID \
+  --location=global \
+  --display-name="GitHub Actions"
+
+# 2. Add GitHub as an OIDC provider inside that pool
+gcloud iam workload-identity-pools providers create-oidc $PROVIDER_ID \
+  --project=$PROJECT_ID \
+  --location=global \
+  --workload-identity-pool=$POOL_ID \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
+  --attribute-condition="assertion.repository=='${REPO}'"
+
+# 3. Create the service account CI will impersonate
+gcloud iam service-accounts create $SA_NAME \
+  --project=$PROJECT_ID \
+  --display-name="GitHub Actions CI"
+
+# 4. Grant the service account permission to push to Artifact Registry
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/artifactregistry.writer"
+
+# 5. Allow the GitHub Actions identity to impersonate the service account
+gcloud iam service-accounts add-iam-policy-binding \
+  "${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --project=$PROJECT_ID \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${REPO}"
+```
+
+### Get the values for GitHub repository variables
+
+After running the commands above, retrieve the two values needed by the workflow:
+
+```bash
+# WIF_PROVIDER — paste this into GitHub → Settings → Variables → WIF_PROVIDER
+echo "projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
+
+# WIF_SERVICE_ACCOUNT — paste this into GitHub → Settings → Variables → WIF_SERVICE_ACCOUNT
+echo "${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+```
+
+These go in **Variables** (not Secrets) in GitHub → Settings → Secrets and variables → Actions → Variables tab. They are not sensitive — they identify the WIF pool, not a credential.
+
+---
+
 ## Token validation strategy
 
 **Decision: Option A — trust the gateway, propagate UID via header.**


### PR DESCRIPTION
## Summary

- `apps/cove-api/Dockerfile` — multi-stage build for the Go service
- `Makefile` (repo root) — local build and test convenience targets
- `.github/workflows/services-ci.yml` — path-filtered CI for all Go services

## Key decisions

**Dockerfile** uses a two-stage build: a full Go toolchain builds the binary, then only the binary is copied into a `distroless/static` image. Distroless has no shell, no package manager, and no OS utilities — just the binary. Much smaller image and minimal attack surface.

**CI workflow** uses `vars.WIF_PROVIDER` and `vars.WIF_SERVICE_ACCOUNT` — GitHub repository *variables* (not secrets, since they're not sensitive). These need to be set once in repo Settings → Variables before the push-to-main path works. The PR path (build only, no push) works without them.

**Path filters** mean changes to `apps/ios/**` never trigger this workflow and vice versa. As Phase 2/3 services are added, each gets a new job in this workflow with its own path filter (`apps/cove-image/**`, etc.).

## Required one-time setup (before merging to main)

Two repository variables need to be configured in GitHub → Settings → Secrets and variables → Actions → Variables:

| Variable | Value |
|---|---|
| `WIF_PROVIDER` | `projects/<project-number>/locations/global/workloadIdentityPools/<pool>/providers/<provider>` |
| `WIF_SERVICE_ACCOUNT` | `<sa-name>@cove-6a685.iam.gserviceaccount.com` |

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)