### PR TITLE
Add services CI workflow with workflow_dispatch

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -1,0 +1,78 @@
+name: CI - Services (Go)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/cove-api/**'
+      - '.github/workflows/services-ci.yml'
+  pull_request:
+    paths:
+      - 'apps/cove-api/**'
+      - '.github/workflows/services-ci.yml'
+  # Allows manually triggering a build+push from any branch.
+  # Useful for bootstrapping GAR before the integration branch merges to main,
+  # or for emergency re-deploys.
+  workflow_dispatch:
+
+jobs:
+  # ── cove-api ──────────────────────────────────────────────────────────────
+  cove-api:
+    name: cove-api
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write   # Required for Workload Identity Federation
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/cove-api/go.mod
+          cache-dependency-path: apps/cove-api/go.sum
+
+      - name: Run tests
+        working-directory: apps/cove-api
+        run: go test ./...
+
+      - name: Run vet
+        working-directory: apps/cove-api
+        run: go vet ./...
+
+      # Authenticate to GCP using Workload Identity Federation.
+      # Runs on pushes to main and on manual workflow_dispatch triggers.
+      # Does not run on PRs — PRs only build the image to verify it compiles.
+      - name: Authenticate to Google Cloud
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for Artifact Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Build and push image (main / manual)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/cove-api
+          push: true
+          tags: us-central1-docker.pkg.dev/cove/services/cove-api:sha-${{ github.sha }}
+          build-args: COMMIT_SHA=${{ github.sha }}
+
+      # On PRs: build only (no push) to verify the Dockerfile and that the
+      # service still compiles. The image is not tagged or stored.
+      - name: Build image (PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/cove-api
+          push: false
+          build-args: COMMIT_SHA=${{ github.sha }}


### PR DESCRIPTION
## Summary

- Brings `services-ci.yml` to `main` so the manual trigger button is visible in the Actions UI
- The `workflow_dispatch` trigger lets us manually build and push the `cove-api` image to GAR from any branch, without needing to wait for the Phase 1 integration branch to merge
- This unblocks writing the Kustomize manifests for #233, which need a real image tag to pin in the staging overlay

## Why this targets main directly

The full Phase 1 work lives on `feature/228-phase-1-gateway`. The workflow file needs to be on the default branch for GitHub to show the manual trigger button — the integration branch alone isn't enough.

When the integration branch eventually merges, git will reconcile both copies of the file cleanly (same content).

## Test plan

- [ ] After merge, verify the "Run workflow" button appears at https://github.com/danicajiao/cove/actions/workflows/services-ci.yml
- [ ] Trigger manually from `feature/228-phase-1-gateway`, confirm image is pushed to GAR as `sha-<commit>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)