### PR TITLE
Fix GAR project ID in services CI image URL

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           context: apps/cove-api
           push: true
-          tags: us-central1-docker.pkg.dev/cove/services/cove-api:sha-${{ github.sha }}
+          tags: us-central1-docker.pkg.dev/cove-6a685/services/cove-api:sha-${{ github.sha }}
           build-args: COMMIT_SHA=${{ github.sha }}
 
       # On PRs: build only (no push) to verify the Dockerfile and that the


### PR DESCRIPTION
## Summary

- Fixes the `tags:` URL in `services-ci.yml` — `cove` → `cove-6a685`
- The wrong project ID caused the image push to fail with a permissions error: `Permission denied on resource "projects/cove/..."` — GCP couldn't find a project named `cove` because the actual project ID is `cove-6a685`
- The build compiled and layered successfully; only the final registry push failed

Caught from failed run: https://github.com/danicajiao/cove/actions/runs/26120912779

🤖 Generated with [Claude Code](https://claude.com/claude-code)