### PR TITLE
Update APIEnvironment staging URL to confirmed hostname (#234)

### DIFF
--- a/apps/ios/Cove/Networking/APIEnvironment.swift
+++ b/apps/ios/Cove/Networking/APIEnvironment.swift
@@ -21,10 +21,6 @@ import Foundation
 /// a recompile, replace `current` with an Info.plist lookup and add a
 /// `API_BASE_URL` key to each scheme's Run configuration.
 ///
-/// ## Staging URL
-///
-/// The staging URL below is a placeholder — confirm the actual hostname when the
-/// staging Cloudflare Tunnel is provisioned in Phase 1.
 enum APIEnvironment {
     case staging
     case production
@@ -34,10 +30,8 @@ enum APIEnvironment {
     var baseURL: URL {
         switch self {
         case .staging:
-            // Placeholder — confirm hostname when Phase 1 staging Cloudflare Tunnel is provisioned.
-            // Candidate: https://staging.api.coveapp.dev
             // swiftlint:disable:next force_unwrapping
-            URL(string: "https://staging.api.coveapp.dev")!
+            URL(string: "https://api.staging.coveapp.dev")!
         case .production:
             // swiftlint:disable:next force_unwrapping
             URL(string: "https://api.coveapp.dev")!

--- a/apps/ios/Cove/Networking/APIEnvironment.swift
+++ b/apps/ios/Cove/Networking/APIEnvironment.swift
@@ -31,7 +31,7 @@ enum APIEnvironment {
         switch self {
         case .staging:
             // swiftlint:disable:next force_unwrapping
-            URL(string: "https://api.staging.coveapp.dev")!
+            URL(string: "https://staging-api.coveapp.dev")!
         case .production:
             // swiftlint:disable:next force_unwrapping
             URL(string: "https://api.coveapp.dev")!


### PR DESCRIPTION
## Summary
- Updates `APIEnvironment.staging.baseURL` from the placeholder `https://staging.api.coveapp.dev` to the confirmed hostname `https://staging-api.coveapp.dev`
- Removes the stale placeholder comment that was left pending Phase 1 tunnel provisioning

## Test plan
- [x] danicajiao/homelab#28 merged and DNS CNAMEs in place
- [x] Debug build on device confirms `APIEnvironment.current` resolves to `https://staging-api.coveapp.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)