### PR TITLE
Document cross-repo reference conventions (cove ↔ homelab)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,17 @@ GitHub's `Closes #<issue-id>` keyword in the PR body is the standard linking mec
 
 The REST API `issue` parameter (`gh api ... -F issue=<id>`) converts an issue into a PR (same number, title/body carry over), but GitHub blocks this for any issue that has a parent/sub-issue relationship — which is every issue in this repo. The GraphQL API has no mutation for setting Development links either. Manual UI linking or `Closes #X` against main are the only two mechanisms that work.
 
+### Cross-repo references
+
+This project spans two repos: `danicajiao/cove` (app + services) and `danicajiao/homelab` (infrastructure). A bare `#number` in any PR or issue body always resolves within the repo it lives in. **Always use the fully qualified `owner/repo#number` format when referencing across repos.**
+
+| Situation | Correct | Wrong |
+|---|---|---|
+| Referencing a homelab PR from a cove PR | `danicajiao/homelab#28` | `#28` |
+| Referencing a cove issue from a homelab PR | `danicajiao/cove#234` | `#234` |
+
+Note: `Closes owner/repo#N` does **not** auto-close cross-repo — GitHub only auto-closes issues in the same repo. Cross-repo references are documentation only.
+
 ### Issue dependency linking
 
 Use the GitHub issue dependencies API to formally mark which issues block which. This shows a "Blocked by #X" indicator in the issue sidebar — more visible than a line in the body, and machine-readable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,29 @@ See `docs/` for architecture details: `APP_ARCHITECTURE.md`, `QUICK_START.md`, `
 
 ---
 
+## Git Workflow
+
+### Switching branches
+
+Always `git pull` immediately after switching to an existing branch — integration branches, `main`, and long-lived feature branches all receive commits from other contributors and agents. Starting work on a stale branch causes unnecessary conflicts.
+
+```bash
+git checkout feature/228-phase-1-gateway
+git pull  # always — before touching anything
+```
+
+### Creating branches
+
+Always set the remote upstream when pushing a new branch for the first time (`-u`). This lets subsequent `git pull` and `git push` calls work without specifying the remote explicitly.
+
+```bash
+git checkout -b feature/123-my-feature
+# ... commit changes ...
+git push -u origin feature/123-my-feature  # -u on first push, always
+```
+
+---
+
 ## Branch Naming
 
 Format: `<label>/<issue-id>-<description-in-kebab-case>`

--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ PR titles or descriptions should include a closing keyword and the issue number 
 Closes #21
 ```
 
+This project spans two repos (`danicajiao/cove` and `danicajiao/homelab`). When referencing an issue or PR in the other repo, always use the fully qualified format so GitHub links it correctly:
+
+```
+danicajiao/homelab#28   ← referencing a homelab PR from cove
+danicajiao/cove#234     ← referencing a cove issue from homelab
+```
+
+Note: `Closes owner/repo#N` does not auto-close cross-repo — GitHub only auto-closes within the same repo.
+
 ### CI
 
 Every PR automatically runs SwiftFormat and SwiftLint checks. Main branch runs a full build and test suite via Fastlane.


### PR DESCRIPTION
## Summary
- Adds a **Cross-repo references** section to `CLAUDE.md` — agents and contributors must use `owner/repo#number` when linking across `danicajiao/cove` and `danicajiao/homelab`; bare `#number` silently resolves within the current repo
- Adds the same convention to `README.md` in the Pull Requests section with examples
- Prompted by danicajiao/homelab#28 being referenced as bare `#27` in cove PR #303, which linked to the wrong issue

## Test plan
- [x] `CLAUDE.md` cross-repo section covers both directions (cove → homelab, homelab → cove)
- [x] `README.md` Pull Requests section includes qualified reference examples and the auto-close caveat

🤖 Generated with [Claude Code](https://claude.com/claude-code)