### PR TITLE
Standardize branch naming to REPO-issue# prefix convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,9 @@ git pull  # always — before touching anything
 Always set the remote upstream when pushing a new branch for the first time (`-u`). This lets subsequent `git pull` and `git push` calls work without specifying the remote explicitly.
 
 ```bash
-git checkout -b feature/123-my-feature
+git checkout -b feature/COVE-123-my-feature
 # ... commit changes ...
-git push -u origin feature/123-my-feature  # -u on first push, always
+git push -u origin feature/COVE-123-my-feature  # -u on first push, always
 ```
 
 ---
@@ -181,7 +181,7 @@ github-project-planner
         └── (optional) creates integration branch: feature/<epic-id>-<description>
               └── sub-issue is picked up by an agent
                     └── harness spins up a worktree: branch claude/<name>, isolated directory
-                          └── agent renames branch: feature/<issue-id>-<desc>
+                          └── agent renames branch: feature/COVE-<issue-id>-<desc>
                                 └── agent implements, runs swiftformat + swiftlint from the affected app dir, commits, pushes
                                       └── PR created targeting integration branch (or main) with "Closes #<issue-id>"
                                             └── PRs merged into integration branch → tested
@@ -209,7 +209,7 @@ This rule applies to every agent **and** to the main session. If the MCP propaga
 ### When you are running as an agent in a worktree
 
 - You are already on an isolated branch (initially named `claude/<worktree-name>`) — do not run `git checkout -b`
-- Rename the branch to follow the naming convention before pushing: `git branch -m <label>/<issue-id>-<description>`
+- Rename the branch to follow the naming convention before pushing: `git branch -m <label>/COVE-<issue-id>-<description>`
 - For iOS work: `cd apps/ios` before running `swiftformat .` and `swiftlint`
 - Commit and push your changes to that branch
 - Open a PR targeting the epic's integration branch (provided in your task prompt) or `main` if there is no epic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,17 @@ GitHub's `Closes #<issue-id>` keyword in the PR body is the standard linking mec
 
 The REST API `issue` parameter (`gh api ... -F issue=<id>`) converts an issue into a PR (same number, title/body carry over), but GitHub blocks this for any issue that has a parent/sub-issue relationship — which is every issue in this repo. The GraphQL API has no mutation for setting Development links either. Manual UI linking or `Closes #X` against main are the only two mechanisms that work.
 
+### Cross-repo references
+
+This project spans two repos: `danicajiao/cove` (app + services) and `danicajiao/homelab` (infrastructure). A bare `#number` in any PR or issue body always resolves within the repo it lives in. **Always use the fully qualified `owner/repo#number` format when referencing across repos.**
+
+| Situation | Correct | Wrong |
+|---|---|---|
+| Referencing a homelab PR from a cove PR | `danicajiao/homelab#28` | `#28` |
+| Referencing a cove issue from a homelab PR | `danicajiao/cove#234` | `#234` |
+
+Note: `Closes owner/repo#N` does **not** auto-close cross-repo — GitHub only auto-closes issues in the same repo. Cross-repo references are documentation only.
+
 ### Issue dependency linking
 
 Use the GitHub issue dependencies API to formally mark which issues block which. This shows a "Blocked by #X" indicator in the issue sidebar — more visible than a line in the body, and machine-readable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,29 @@ See `docs/` for architecture details: `APP_ARCHITECTURE.md`, `QUICK_START.md`, `
 
 ---
 
+## Git Workflow
+
+### Switching branches
+
+Always `git pull` immediately after switching to an existing branch — integration branches, `main`, and long-lived feature branches all receive commits from other contributors and agents. Starting work on a stale branch causes unnecessary conflicts.
+
+```bash
+git checkout feature/228-phase-1-gateway
+git pull  # always — before touching anything
+```
+
+### Creating branches
+
+Always set the remote upstream when pushing a new branch for the first time (`-u`). This lets subsequent `git pull` and `git push` calls work without specifying the remote explicitly.
+
+```bash
+git checkout -b feature/123-my-feature
+# ... commit changes ...
+git push -u origin feature/123-my-feature  # -u on first push, always
+```
+
+---
+
 ## Branch Naming
 
 Format: `<label>/<issue-id>-<description-in-kebab-case>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,12 @@ git push -u origin feature/123-my-feature  # -u on first push, always
 
 ## Branch Naming
 
-Format: `<label>/<issue-id>-<description-in-kebab-case>`
+Format: `<label>/<REPO>-<issue-number>-<short-description-in-kebab-case>`
+
+When no GitHub issue exists for the change, omit the `<REPO>-<issue-number>` segment:
+`<label>/<short-description-in-kebab-case>`
+
+The `<REPO>` prefix is always ALL CAPS and identifies which repo's issue tracker the number comes from. For this repo all issues live in `COVE` (`danicajiao/cove`). If a branch is opened in `danicajiao/homelab` for a cove issue, the prefix is still `COVE`.
 
 | Label | Use |
 |---|---|
@@ -59,11 +64,14 @@ Format: `<label>/<issue-id>-<description-in-kebab-case>`
 | `docs/` | Documentation-only changes |
 | `chore/` | Maintenance, config, tooling |
 
-Examples:
-- `feature/137-profile-view-model`
-- `enhancement/66-improve-tab-navigation`
-- `bug/3-fix-login-crash`
+Examples — with issue:
+- `feature/COVE-137-profile-view-model`
+- `enhancement/COVE-66-improve-tab-navigation`
+- `bug/COVE-3-fix-login-crash`
+
+Examples — no issue (off-cycle fixes):
 - `docs/update-readme`
+- `chore/bump-cloudflared-2026-6`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ PR titles or descriptions should include a closing keyword and the issue number 
 Closes #21
 ```
 
+This project spans two repos (`danicajiao/cove` and `danicajiao/homelab`). When referencing an issue or PR in the other repo, always use the fully qualified format so GitHub links it correctly:
+
+```
+danicajiao/homelab#28   ← referencing a homelab PR from cove
+danicajiao/cove#234     ← referencing a cove issue from homelab
+```
+
+Note: `Closes owner/repo#N` does not auto-close cross-repo — GitHub only auto-closes within the same repo.
+
 ### CI
 
 Every PR automatically runs SwiftFormat and SwiftLint checks. Main branch runs a full build and test suite via Fastlane.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ See [App Architecture](docs/APP_ARCHITECTURE.md) for a detailed breakdown of how
 
 This project uses trunk-based development. Every branch is tied to a GitHub issue.
 
-Format: `<label>/<issue-id>-<description-in-kebab-case>`
+Format: `<label>/<REPO>-<issue-number>-<short-description>` when a GitHub issue exists, or `<label>/<short-description>` for off-cycle changes with no issue.
+
+The `<REPO>` prefix is ALL CAPS and identifies the issue tracker — always `COVE` for this repo.
 
 | Label | Use |
 |---|---|
@@ -129,7 +131,7 @@ Format: `<label>/<issue-id>-<description-in-kebab-case>`
 | `docs/` | Documentation-only changes |
 | `chore/` | Maintenance, config, tooling |
 
-Examples: `feature/21-favorites-view`, `bug/3-fix-login-crash`, `docs/update-readme`
+Examples: `feature/COVE-21-favorites-view`, `bug/COVE-3-fix-login-crash`, `docs/update-readme`
 
 ### Pull Requests
 


### PR DESCRIPTION
## Summary
- Updates branch naming format in `CLAUDE.md` and `README.md` to `<label>/<REPO>-<issue#>-<description>` (e.g. `feature/COVE-234-cloudflare-tunnel-routing`)
- `<REPO>` is always ALL CAPS — always `COVE` since all issues live in `danicajiao/cove`
- Issue number is required when an issue exists; omitted for off-cycle changes with no issue
- Reconciles `fix/` → `bug/` in the label table

Follows on from danicajiao/cove#304 (cross-repo refs + git workflow, already merged into integration branch).

## Test plan
- [x] `CLAUDE.md` branch naming section reflects new format with examples
- [x] `README.md` Contributing/Branching section matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)