### PR TITLE
Add Debug-only gateway smoke test on app launch

### DIFF
--- a/apps/ios/Cove.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/Cove.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7b506257b020b60dcfcb197a8276c553c3e1d7fbcc23ff2fc4e35d84bcd77811",
+  "originHash" : "3964884c0aba2393277801b9c30d3316c0ea9d56b2f4144117b7d6fa2662bf11",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/apps/ios/Cove/Networking/CoveAPIClient.swift
+++ b/apps/ios/Cove/Networking/CoveAPIClient.swift
@@ -7,6 +7,7 @@
 
 import FirebaseAuth
 import Foundation
+import HTTPTypes
 import OpenAPIRuntime
 import OpenAPIURLSession
 

--- a/apps/ios/Cove/Networking/CoveAPIClient.swift
+++ b/apps/ios/Cove/Networking/CoveAPIClient.swift
@@ -7,7 +7,6 @@
 
 import FirebaseAuth
 import Foundation
-import HTTPTypes
 import OpenAPIRuntime
 import OpenAPIURLSession
 

--- a/apps/ios/Cove/Supporting Files/CoveApp.swift
+++ b/apps/ios/Cove/Supporting Files/CoveApp.swift
@@ -9,8 +9,33 @@ import FBSDKCoreKit
 import FirebaseAuth
 import FirebaseCore
 import GoogleSignIn
+import OSLog
 import SwiftUI
 import UIKit
+
+// MARK: - Gateway smoke test
+
+#if DEBUG
+    private extension CoveApp {
+        /// Calls `GET /health` once at launch and logs the result.
+        ///
+        /// Exercises the full path: iOS → Cloudflare Tunnel → cove-api gateway.
+        /// `/health` is unauthenticated so this runs before the user signs in.
+        /// Failure is logged but never surfaces to the user — it must not block
+        /// or alter app launch in any way.
+        func runGatewaySmokeTest() async {
+            let logger = Logger(subsystem: "com.danicajiao.cove", category: "SmokeTest")
+            do {
+                let health = try await CoveAPIClient.shared.health()
+                logger.info("✓ cove-api reachable — service: \(health.service), status: \(health.status), commit: \(health.commit)")
+            } catch {
+                logger.warning("✗ cove-api smoke test failed: \(error.localizedDescription)")
+            }
+        }
+    }
+#endif
+
+// MARK: - AppDelegate
 
 /// no changes in your AppDelegate class
 class AppDelegate: NSObject, UIApplicationDelegate {
@@ -75,6 +100,11 @@ struct CoveApp: App {
                         }
                     }
                 }
+            }
+            .task {
+                #if DEBUG
+                    await runGatewaySmokeTest()
+                #endif
             }
             .onChange(of: appState.authState) { _, _ in
                 authPath = []


### PR DESCRIPTION
## Summary

- Adds a `#if DEBUG`-only smoke test that fires once on every cold start via a `.task` modifier on `CoveApp`'s root `Group`
- Calls `CoveAPIClient.shared.health()` in a background `Task` and logs the result via `OSLog` under the `SmokeTest` category
- Success: `✓ cove-api reachable — service: cove-api, status: ok, commit: <sha>`
- Failure: `✗ cove-api smoke test failed: <error description>`
- Completely silent in Release builds — no UI changes, no launch impact

## Why `CoveApp` rather than `WelcomeView`

`WelcomeView` only appears when the user is logged out. Placing the test on the root `Group` in `CoveApp` guarantees it runs on every cold start regardless of auth state.

## Test plan

- [x] Build and run in Debug on a simulator or device
- [x] Open Console.app (or Xcode debug console), filter by subsystem `com.danicajiao.cove` and category `SmokeTest`
- [x] Verify `✓ cove-api reachable` log line appears within a few seconds of launch
- [x] Build in Release — confirm no SmokeTest log output
- [x] CI passes

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)