### PR TITLE
Add cove-image OpenAPI spec to CI lint coverage

### DIFF
--- a/.github/workflows/ci-openapi.yml
+++ b/.github/workflows/ci-openapi.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'services/cove-api/api/**'
+      - 'services/cove-image/api/**'
       - '.github/workflows/ci-openapi.yml'
 
 jobs:
@@ -18,5 +19,8 @@ jobs:
       - name: Install Redocly CLI
         run: npm install -g @redocly/cli@latest
 
-      - name: Lint openapi.yaml
+      - name: Lint cove-api openapi.yaml
         run: redocly lint --config services/cove-api/redocly.yaml services/cove-api/api/openapi.yaml
+
+      - name: Lint cove-image openapi.yaml
+        run: redocly lint --config services/cove-image/redocly.yaml services/cove-image/api/openapi.yaml

--- a/services/cove-image/redocly.yaml
+++ b/services/cove-image/redocly.yaml
@@ -1,0 +1,6 @@
+rules:
+  # Not applicable — cove-image is a private internal service, not a public API.
+  info-license: off
+
+  # localhost:8080 is a legitimate local development server, not an example placeholder.
+  no-server-example.com: off


### PR DESCRIPTION
## Summary

- Extends `ci-openapi.yml` to lint `services/cove-image/api/openapi.yaml` on every PR that touches it
- Adds `services/cove-image/redocly.yaml` config (mirrors cove-api — internal service, no license rule needed)

The spec content itself was completed across #239 (upload endpoint) and #241 (signed-URL fetch endpoint). This PR closes out the CI coverage gap from #242.

## Test plan

- [x] `redocly lint` passes locally — `Your API description is valid. 🎉`
- [x] CI lint step passes on this PR

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
