### PR TITLE
Wire /images/* and /i/* reverse proxies in cove-api

### DIFF
--- a/services/cove-api/cmd/api/main.go
+++ b/services/cove-api/cmd/api/main.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"os"
 
 	firebase "firebase.google.com/go/v4"
@@ -29,6 +31,15 @@ func main() {
 	// development without credentials and by Kubernetes probes during startup.
 	r.Get("/health", healthHandler)
 
+	// /i/* proxies to imgproxy unauthenticated — imgproxy validates its own
+	// HMAC-SHA256 URL signature, so a Firebase token is not required here.
+	// This allows Cloudflare to cache image responses without needing a token.
+	imgproxyURL := os.Getenv("IMGPROXY_URL")
+	if imgproxyURL == "" {
+		imgproxyURL = "http://imgproxy:8080"
+	}
+	r.Handle("/i/*", imgproxyHandler(imgproxyURL))
+
 	// Initialise Firebase and wire protected routes only when credentials are
 	// provided.  Without FIREBASE_CREDENTIALS_PATH the server still starts and
 	// /health works; all other routes return 401.
@@ -46,10 +57,24 @@ func main() {
 			log.Fatalf("failed to initialise Firebase Auth client: %v", err)
 		}
 
-		// All routes except /health are protected by Firebase ID-token validation.
+		// cove-image URL — defaults to the in-cluster Service name, which
+		// resolves within the same namespace without a full DNS path.
+		coveImageURL := os.Getenv("COVE_IMAGE_URL")
+		if coveImageURL == "" {
+			coveImageURL = "http://cove-image:8080"
+		}
+
+		// All routes except /health and /i/* are protected by Firebase
+		// ID-token validation.
 		r.Group(func(r chi.Router) {
 			r.Use(covauth.Middleware(authClient))
-			// Authenticated routes are added here in later sub-issues.
+
+			// /images and /images/* proxy to cove-image. The authenticated
+			// UID is injected as X-Cove-Uid so cove-image can trust it
+			// without re-validating the Firebase token itself.
+			imgHandler := coveImageHandler(coveImageURL)
+			r.Handle("/images", imgHandler)
+			r.Handle("/images/*", imgHandler)
 		})
 
 		log.Println("Firebase Auth initialised — protected routes active")
@@ -66,6 +91,54 @@ func main() {
 	if err := http.ListenAndServe(":"+port, r); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
+}
+
+// coveImageHandler returns a reverse proxy handler for cove-image.
+//
+// The handler injects the authenticated Firebase UID as X-Cove-Uid so
+// cove-image can trust it without re-validating the token. The full request
+// path is forwarded unchanged so cove-image's own router handles dispatch
+// (e.g. POST /images vs GET /images/{filename}/url).
+func coveImageHandler(targetURL string) http.Handler {
+	target, err := url.Parse(targetURL)
+	if err != nil {
+		log.Fatalf("invalid COVE_IMAGE_URL %q: %v", targetURL, err)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		log.Printf("ERROR: cove-image proxy: %v", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":"image service unavailable"}`))
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Propagate the verified UID. cove-image rejects requests without
+		// this header — safe because cove-image is not externally reachable.
+		if uid, ok := covauth.UIDFromContext(r.Context()); ok {
+			r.Header.Set("X-Cove-Uid", uid)
+		}
+		proxy.ServeHTTP(w, r)
+	})
+}
+
+// imgproxyHandler returns a reverse proxy handler for imgproxy.
+//
+// The /i prefix is stripped before forwarding so imgproxy receives the path
+// in its expected form: /<signature>/<processing_options>/plain/<source>.
+// imgproxy validates its own HMAC-SHA256 URL signature — no Firebase token
+// is required at this layer.
+func imgproxyHandler(targetURL string) http.Handler {
+	target, err := url.Parse(targetURL)
+	if err != nil {
+		log.Fatalf("invalid IMGPROXY_URL %q: %v", targetURL, err)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		log.Printf("ERROR: imgproxy proxy: %v", err)
+		w.WriteHeader(http.StatusBadGateway)
+	}
+	// Strip /i so imgproxy sees /<sig>/... rather than /i/<sig>/...
+	return http.StripPrefix("/i", proxy)
 }
 
 // healthHandler returns 200 with a JSON body identifying the service and the


### PR DESCRIPTION
## Summary

Adds two reverse proxy routes to cove-api — the last piece before signed image URLs work end-to-end from the iOS app.

| Route | Target | Auth |
|---|---|---|
| `/images`, `/images/*` | cove-image | Firebase token required — UID injected as `X-Cove-Uid` |
| `/i/*` | imgproxy | Unauthenticated — imgproxy validates its own HMAC-SHA256 signature |

## Why `/i/*` is unauthenticated

imgproxy's URL signing already provides request integrity — only cove-image (holding the key/salt) can generate valid URLs. Requiring a Firebase token on top would prevent Cloudflare from caching image responses at the edge, and would require the iOS client to attach a token to every image fetch.

## New env vars (cove-api Deployment)

| Var | Default | Description |
|---|---|---|
| `COVE_IMAGE_URL` | `http://cove-image:8080` | In-cluster cove-image Service |
| `IMGPROXY_URL` | `http://imgproxy:8080` | In-cluster imgproxy Service |

Both default to the short Service DNS name, which resolves within the same namespace — no homelab overlay changes needed.

## Test plan

- [x] `go build ./...` + `go vet ./...` + `go test ./...` — all pass
- [x] Local smoke: `/health` 200, `/i/*` forwards to imgproxy (strips `/i` prefix), `/images` 404 in local dev mode (Firebase disabled — expected)
- [ ] After merge + dispatch: upload via `POST https://staging-api.coveapp.dev/images`, confirm 201 and object in Garage
- [ ] Follow a signed URL via `GET https://staging-api.coveapp.dev/i/<sig>/...`, confirm 200 + resized WebP

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
