### PR TITLE
Add bump-staging-tags CD job to ci-services workflow

### DIFF
--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -18,6 +18,10 @@ on:
   # or for emergency re-deploys.
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── cove-api ──────────────────────────────────────────────────────────────
   cove-api:

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -218,7 +218,7 @@ jobs:
 
           gh pr create \
             --repo danicajiao/homelab \
-            --title "Bump cove services to ${NEW_TAG}" \
+            --title "Bump cove services to sha-${SHORT_SHA}" \
             --body-file /tmp/pr-body.md \
             --base main \
             --head "${BRANCH}"

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -141,3 +141,69 @@ jobs:
           context: services/cove-image
           push: false
           build-args: COMMIT_SHA=${{ github.sha }}
+
+  # ── bump-staging-tags ─────────────────────────────────────────────────────
+  bump-staging-tags:
+    name: Open homelab PR — bump staging tags
+    runs-on: ubuntu-latest
+    needs: [cove-api, cove-image]
+    # Only runs after a successful image push — same gate as the push steps above.
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout homelab
+        uses: actions/checkout@v6
+        with:
+          repository: danicajiao/homelab
+          token: ${{ secrets.HOMELAB_PAT }}
+
+      - name: Bump staging image tags
+        run: |
+          NEW_TAG="sha-${{ github.sha }}"
+          sed -i "s|newTag: sha-[0-9a-f]*|newTag: ${NEW_TAG}|g" \
+            apps/cove/overlays/staging/kustomization.yaml
+
+      - name: Open PR in homelab
+        env:
+          GH_TOKEN: ${{ secrets.HOMELAB_PAT }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          SHORT_SHA="${COMMIT_SHA:0:8}"
+          NEW_TAG="sha-${COMMIT_SHA}"
+          BRANCH="chore/bump-cove-sha-${SHORT_SHA}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add apps/cove/overlays/staging/kustomization.yaml
+          git commit -m "chore: bump cove services to sha-${SHORT_SHA}"
+          git push origin "${BRANCH}"
+
+          cat > /tmp/pr-body.md << EOF
+          ## Staging Deploy
+
+          Bumps all cove services in \`apps/cove/overlays/staging\` to \`${NEW_TAG}\`.
+
+          | Service | New tag |
+          |---|---|
+          | \`cove-api\` | \`${NEW_TAG}\` |
+          | \`cove-image\` | \`${NEW_TAG}\` |
+
+          **Source:** [danicajiao/cove@${SHORT_SHA}](https://github.com/danicajiao/cove/commit/${COMMIT_SHA})
+          **CI run:** https://github.com/danicajiao/cove/actions/runs/${RUN_ID}
+
+          ## Checklist
+          - [ ] CI green on source commit
+          - [ ] No unexpected manifest changes in diff
+          EOF
+
+          gh pr create \
+            --repo danicajiao/homelab \
+            --title "chore: bump cove services to ${NEW_TAG}" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "${BRANCH}"

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -218,7 +218,7 @@ jobs:
 
           gh pr create \
             --repo danicajiao/homelab \
-            --title "Bump cove services to sha-${SHORT_SHA}" \
+            --title "Bump cove services to SHA \`${SHORT_SHA}\`" \
             --body-file /tmp/pr-body.md \
             --base main \
             --head "${BRANCH}"

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -142,9 +142,9 @@ jobs:
           push: false
           build-args: COMMIT_SHA=${{ github.sha }}
 
-  # ── bump-staging-tags ─────────────────────────────────────────────────────
-  bump-staging-tags:
-    name: Open homelab PR — bump staging tags
+  # ── bump-overlay-tags ─────────────────────────────────────────────────────
+  bump-overlay-tags:
+    name: Open homelab PR — bump overlay tags
     runs-on: ubuntu-latest
     needs: [cove-api, cove-image]
     # Only runs after a successful image push — same gate as the push steps above.
@@ -160,38 +160,53 @@ jobs:
           repository: danicajiao/homelab
           token: ${{ secrets.HOMELAB_PAT }}
 
-      - name: Bump staging image tags
-        run: |
-          NEW_TAG="sha-${{ github.sha }}"
-          sed -i "s|newTag: sha-[0-9a-f]*|newTag: ${NEW_TAG}|g" \
-            apps/cove/overlays/staging/kustomization.yaml
-
-      - name: Open PR in homelab
+      - name: Bump overlay image tags and open PR
         env:
           GH_TOKEN: ${{ secrets.HOMELAB_PAT }}
           COMMIT_SHA: ${{ github.sha }}
           RUN_ID: ${{ github.run_id }}
+          GIT_REF: ${{ github.ref }}
         run: |
           SHORT_SHA="${COMMIT_SHA:0:8}"
           NEW_TAG="sha-${COMMIT_SHA}"
-          BRANCH="deploy/cove-staging-sha-${SHORT_SHA}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # On main: update both staging and prod overlays in one PR so they
+          # are always in sync after a release. On any other branch (e.g. an
+          # integration branch workflow_dispatch): staging only for validation.
+          if [ "$GIT_REF" = "refs/heads/main" ]; then
+            OVERLAYS="apps/cove/overlays/staging/kustomization.yaml apps/cove/overlays/prod/kustomization.yaml"
+            BRANCH="deploy/cove-sha-${SHORT_SHA}"
+            ENV_LABEL="staging + prod"
+          else
+            OVERLAYS="apps/cove/overlays/staging/kustomization.yaml"
+            BRANCH="deploy/cove-staging-sha-${SHORT_SHA}"
+            ENV_LABEL="staging"
+          fi
+
+          for f in $OVERLAYS; do
+            sed -i "s|newTag: sha-[0-9a-f]*|newTag: ${NEW_TAG}|g" "$f"
+          done
+
           git checkout -b "${BRANCH}"
-          git add apps/cove/overlays/staging/kustomization.yaml
-          git commit -m "chore: bump cove services to sha-${SHORT_SHA}"
+          git add $OVERLAYS
+          git commit -m "Bump cove services to sha-${SHORT_SHA} (${ENV_LABEL})"
           git push origin "${BRANCH}"
 
           cat > /tmp/pr-body.md << EOF
-          ## Staging Deploy
+          ## Deploy — ${ENV_LABEL}
 
-          Bumps all cove services in \`apps/cove/overlays/staging\` to \`${NEW_TAG}\`.
+          Bumps all cove services to \`${NEW_TAG}\`.
 
-          | Service | New tag |
-          |---|---|
-          | \`cove-api\` | \`${NEW_TAG}\` |
-          | \`cove-image\` | \`${NEW_TAG}\` |
+          | Overlay | Service | New tag |
+          |---|---|---|
+          $(for f in $OVERLAYS; do
+            ENV=$(echo "$f" | grep -o 'staging\|prod')
+            echo "          | \`${ENV}\` | \`cove-api\` | \`${NEW_TAG}\` |"
+            echo "          | \`${ENV}\` | \`cove-image\` | \`${NEW_TAG}\` |"
+          done)
 
           **Source:** [danicajiao/cove@${SHORT_SHA}](https://github.com/danicajiao/cove/commit/${COMMIT_SHA})
           **CI run:** https://github.com/danicajiao/cove/actions/runs/${RUN_ID}

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -203,7 +203,7 @@ jobs:
 
           gh pr create \
             --repo danicajiao/homelab \
-            --title "chore: bump cove services to ${NEW_TAG}" \
+            --title "Bump cove services to ${NEW_TAG}" \
             --body-file /tmp/pr-body.md \
             --base main \
             --head "${BRANCH}"

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -195,26 +195,26 @@ jobs:
           git commit -m "Bump cove services to sha-${SHORT_SHA} (${ENV_LABEL})"
           git push origin "${BRANCH}"
 
-          cat > /tmp/pr-body.md << EOF
-          ## Deploy — ${ENV_LABEL}
-
-          Bumps all cove services to \`${NEW_TAG}\`.
-
-          | Overlay | Service | New tag |
-          |---|---|---|
-          $(for f in $OVERLAYS; do
-            ENV=$(echo "$f" | grep -o 'staging\|prod')
-            echo "          | \`${ENV}\` | \`cove-api\` | \`${NEW_TAG}\` |"
-            echo "          | \`${ENV}\` | \`cove-image\` | \`${NEW_TAG}\` |"
-          done)
-
-          **Source:** [danicajiao/cove@${SHORT_SHA}](https://github.com/danicajiao/cove/commit/${COMMIT_SHA})
-          **CI run:** https://github.com/danicajiao/cove/actions/runs/${RUN_ID}
-
-          ## Checklist
-          - [ ] CI green on source commit
-          - [ ] No unexpected manifest changes in diff
-          EOF
+          {
+            echo "## Deploy — ${ENV_LABEL}"
+            echo ""
+            echo "Bumps all cove services to \`${NEW_TAG}\`."
+            echo ""
+            echo "| Overlay | Service | New tag |"
+            echo "|---|---|---|"
+            for f in $OVERLAYS; do
+              ENV=$(echo "$f" | grep -o 'staging\|prod')
+              echo "| \`${ENV}\` | \`cove-api\` | \`${NEW_TAG}\` |"
+              echo "| \`${ENV}\` | \`cove-image\` | \`${NEW_TAG}\` |"
+            done
+            echo ""
+            echo "**Source:** [danicajiao/cove@${SHORT_SHA}](https://github.com/danicajiao/cove/commit/${COMMIT_SHA})"
+            echo "**CI run:** https://github.com/danicajiao/cove/actions/runs/${RUN_ID}"
+            echo ""
+            echo "## Checklist"
+            echo "- [ ] CI green on source commit"
+            echo "- [ ] No unexpected manifest changes in diff"
+          } > /tmp/pr-body.md
 
           gh pr create \
             --repo danicajiao/homelab \

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -178,7 +178,7 @@ jobs:
           # integration branch workflow_dispatch): staging only for validation.
           if [ "$GIT_REF" = "refs/heads/main" ]; then
             OVERLAYS="apps/cove/overlays/staging/kustomization.yaml apps/cove/overlays/prod/kustomization.yaml"
-            BRANCH="deploy/cove-sha-${SHORT_SHA}"
+            BRANCH="deploy/cove-prod-sha-${SHORT_SHA}"
             ENV_LABEL="staging + prod"
           else
             OVERLAYS="apps/cove/overlays/staging/kustomization.yaml"

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           SHORT_SHA="${COMMIT_SHA:0:8}"
           NEW_TAG="sha-${COMMIT_SHA}"
-          BRANCH="chore/bump-cove-sha-${SHORT_SHA}"
+          BRANCH="deploy/cove-staging-sha-${SHORT_SHA}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- Adds a `bump-staging-tags` job to `ci-services.yml` that runs after both `cove-api` and `cove-image` images are successfully pushed
- Checks out `danicajiao/homelab`, updates `newTag` for both services in `apps/cove/overlays/staging/kustomization.yaml`, and opens a PR with a structured deploy checklist
- Gated on the same condition as the existing push steps: push to `main` or `workflow_dispatch`

## Prerequisites

Before this workflow can run, add `HOMELAB_PAT` to `danicajiao/cove` → Settings → Secrets → Actions:
- Fine-grained PAT scoped to `danicajiao/homelab`
- Permissions: **Contents** (read & write) + **Pull requests** (read & write)

## Test plan
- [x] Add `HOMELAB_PAT` secret to cove repo settings
- [x] Trigger `workflow_dispatch` on this branch — confirm a PR appears in `danicajiao/homelab` with the correct tag and body
- [x] Verify `apps/cove/overlays/staging/kustomization.yaml` diff shows only the `newTag` lines changed

Closes #333
