### PR TITLE
Sync all docs with Phase 2 image pipeline

### DIFF
--- a/.claude/agents/github-project-planner.md
+++ b/.claude/agents/github-project-planner.md
@@ -13,6 +13,8 @@ You are a technical architect and project planner for an iOS/Swift app. You turn
 - **Always explore the codebase before drafting a plan**
 - **Link sub-issues one at a time, sequentially** — concurrent `addSubIssue` mutations return `422 "Priority has already been taken"`
 - **Use the issue's `node_id` (a string like `I_kwDO...`), not its `number` (integer), for the `addSubIssue` mutation** — fetch it with `gh api repos/danicajiao/cove/issues/<number> --jq '.node_id'`
+- **Every epic must end with a mandatory docs audit sub-issue** (see "Docs audit sub-issue" below)
+- **Wire blocked-by dependency links via the REST API after all sub-issues are created** (see "Dependency wiring" below)
 
 ---
 
@@ -107,6 +109,65 @@ Present the final plan — including which UI sub-issues have Figma links — an
      --head feature/$EPIC_NUMBER-<short-description> \
      --draft
    ```
+
+6. **Add the mandatory docs audit sub-issue** (see "Docs audit sub-issue" below) and link it to the epic.
+
+7. **Wire blocked-by dependency links** for all sub-issues (see "Dependency wiring" below).
+
+---
+
+## Docs audit sub-issue
+
+Every epic must end with a `documentation-maintainer` sub-issue labelled `docs`. This sub-issue is the last leaf in the dependency chain — it is blocked by all other leaf sub-issues and runs after they are merged.
+
+**Template:**
+
+```markdown
+Title: "Docs audit: sync documentation with <epic name>"
+
+Labels: docs
+
+## Description
+Review and update all documentation affected by this epic so it accurately reflects what shipped.
+
+## Acceptance Criteria
+- [ ] All docs files touched by this epic are accurate and up to date
+- [ ] `docs/README.md` index reflects any new or removed docs
+- [ ] No stale references remain (old file paths, retired services, renamed types)
+- [ ] Phase completion status updated in `docs/BACKEND_INFRASTRUCTURE.md` (if applicable)
+
+## Technical Notes
+- Handled by the `documentation-maintainer` agent
+- Integration branch: feature/<epic-id>-<description>
+- Review all docs listed in `docs/README.md` for claims affected by this epic
+
+## Dependencies
+- Blocked by #<all other leaf sub-issue numbers>
+```
+
+Add the `docs` label. Do **not** add `ui/ux`, `backend`, or other area labels to this sub-issue.
+
+---
+
+## Dependency wiring
+
+After all sub-issues (including the docs audit) are created, POST blocked-by links using the REST API so the "Blocked by" indicators appear in the GitHub issue sidebar.
+
+Always use the internal issue `id` (not the issue number) for `issue_id`:
+
+```bash
+# Mark issue #B as blocked by issue #A
+BLOCKING_ID=$(gh api repos/danicajiao/cove/issues/<A> --jq '.id')
+gh api repos/danicajiao/cove/issues/<B>/dependencies/blocked_by \
+  --method POST \
+  -F issue_id=$BLOCKING_ID
+```
+
+**Required wiring for every epic:**
+- Each sub-issue that has a prerequisite → POST a blocked-by link pointing at the prerequisite
+- The docs audit sub-issue → POST blocked-by links for **all leaf sub-issues** (i.e., sub-issues that nothing else in the epic depends on)
+
+Read the `## Dependencies` section of each sub-issue body to determine the correct relationships. Wire them all before the epic is handed off.
 
 ---
 

--- a/.github/agents/github-project-planner.agent.md
+++ b/.github/agents/github-project-planner.agent.md
@@ -15,6 +15,8 @@ You are a technical architect and project planner. You turn initiative requests 
 - **Always explore the codebase before drafting a plan**
 - **Call `github/sub_issue_write` one at a time** — concurrent calls return `422 "Priority has already been taken"`
 - **Use `id` (not `number`) for `sub_issue_id`** — the `id` is a large integer returned in the create response
+- **Every epic must end with a mandatory docs audit sub-issue** (see "Docs audit sub-issue" below)
+- **Wire blocked-by dependency links after all sub-issues are created** (see "Dependency wiring" below)
 
 ---
 
@@ -57,7 +59,53 @@ Wait for the user to approve, adjust, or cancel. Do not proceed without confirma
 ### 5. Execute
 1. Create the epic with `github/issue_write` → capture its `number` and `id`
 2. Create each sub-issue → capture each `id`
-3. Link each sub-issue to the epic with `github/sub_issue_write` — one at a time, sequentially
+3. Create the mandatory docs audit sub-issue (see "Docs audit sub-issue" below) → capture its `id`
+4. Link each sub-issue (including the docs audit) to the epic with `github/sub_issue_write` — one at a time, sequentially
+5. Wire blocked-by dependency links (see "Dependency wiring" below)
+
+---
+
+## Docs audit sub-issue
+
+Every epic must end with a `documentation-maintainer` sub-issue labelled `docs`. This sub-issue is the last leaf in the dependency chain — it is blocked by all other leaf sub-issues and runs after they are merged.
+
+**Template:**
+
+```markdown
+Title: "Docs audit: sync documentation with <epic name>"
+
+Labels: docs
+
+## Description
+Review and update all documentation affected by this epic so it accurately reflects what shipped.
+
+## Acceptance Criteria
+- [ ] All docs files touched by this epic are accurate and up to date
+- [ ] `docs/README.md` index reflects any new or removed docs
+- [ ] No stale references remain (old file paths, retired services, renamed types)
+- [ ] Phase completion status updated in `docs/BACKEND_INFRASTRUCTURE.md` (if applicable)
+
+## Technical Notes
+- Handled by the `documentation-maintainer` agent
+- Review all docs in `docs/` for claims affected by this epic
+
+## Dependencies
+- Blocked by #<all other leaf sub-issue numbers>
+```
+
+Add the `docs` label. Do **not** add `ui/ux`, `backend`, or other area labels to this sub-issue.
+
+---
+
+## Dependency wiring
+
+After all sub-issues (including the docs audit) are created, POST blocked-by links so the "Blocked by" indicators appear in the GitHub issue sidebar. Use `github/issue_write` or the REST API — one dependency link at a time.
+
+**Required wiring for every epic:**
+- Each sub-issue that has a prerequisite → add a blocked-by link pointing at the prerequisite
+- The docs audit sub-issue → add blocked-by links for **all leaf sub-issues** (sub-issues that nothing else in the epic depends on)
+
+Read the `## Dependencies` section of each sub-issue body to determine the correct relationships. Wire them all before the epic is handed off.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Cove is a monorepo containing the Cove iOS app and (eventually) a web client, backend services, and shared packages. The iOS app uses SwiftUI with MVVM, Firebase (Auth, Firestore, Storage), Swift Package Manager, and targets iOS 26+.
+Cove is a monorepo containing the Cove iOS app and (eventually) a web client, backend services, and shared packages. The iOS app uses SwiftUI with MVVM, Firebase (Auth, Firestore), Swift Package Manager, and targets iOS 26+. Firebase Storage was retired in Phase 2; images are served through the `cove-image` service.
 
 **Repo layout:**
 
@@ -11,7 +11,8 @@ cove/
 ├── apps/                   # Client applications
 │   └── ios/                # Swift / SwiftUI iOS app — see apps/ios/Cove/
 ├── services/               # Backend services
-│   └── cove-api/           # Go gateway service (Phase 1) — see services/cove-api/
+│   ├── cove-api/           # Go gateway service (Phase 1) — see services/cove-api/
+│   └── cove-image/         # Go image service (Phase 2) — see services/cove-image/
 ├── packages/               # Shared code (api-schema, design-tokens — planned)
 └── docs/                   # Cross-cutting product/architecture docs
 ```
@@ -100,8 +101,10 @@ The app talks to two completely independent backends. Never mix them up:
 
 | Backend | How to call it | Used for |
 |---|---|---|
-| Firebase | Firebase iOS SDK (`FirebaseAuth`, `FirebaseFirestore`, `FirebaseStorage`) | Auth, Firestore data, Storage images |
-| cove-api gateway | `CoveAPIClient` | All gateway endpoints |
+| Firebase | Firebase iOS SDK (`FirebaseAuth`, `FirebaseFirestore`) | Auth, Firestore data |
+| cove-api gateway | `CoveAPIClient` | All gateway endpoints, including image loading via `CoveAPIImageRepository` |
+
+Note: `FirebaseStorage` was retired in Phase 2 and is no longer linked in the iOS Xcode target. All image loading now goes through `CoveAPIClient` → `cove-api` → `cove-image`.
 
 ### CoveAPIClient — the only path to cove-api
 

--- a/docs/BACKEND_INFRASTRUCTURE.md
+++ b/docs/BACKEND_INFRASTRUCTURE.md
@@ -1,6 +1,6 @@
 # Backend Infrastructure
 
-> **Status:** Phases 0 and 1 complete. The cluster is fully bootstrapped and running, and the `cove-api` gateway is deployed to `cove-staging` and `cove-prod` behind the Cloudflare Tunnel. The iOS app routes gateway calls through `CoveAPIClient` while still using Firebase directly for Auth, Firestore, and Storage — the remaining backend services come online in Phases 2–3 one at a time. Firebase Auth is kept throughout.
+> **Status:** Phases 0, 1, and 2 complete. The cluster is fully bootstrapped and running. `cove-api` and `cove-image` are deployed to `cove-staging` and `cove-prod` behind the Cloudflare Tunnel. The iOS app routes all image requests through `CoveAPIClient` → `cove-api` → `cove-image`; Firebase Storage has been retired. Firebase Auth and Firestore remain in use until Phase 3.
 
 ## Contents
 
@@ -42,7 +42,8 @@ cove-api  (K3s pod, cove-staging / cove-prod namespace)
     │  Validates Firebase ID Token via Firebase Admin SDK
     │  Routes to backend services by path prefix
     │
-    ├── /images/*  ──►  cove-image   (Phase 2)
+    ├── /images/*  ──►  cove-image   (Phase 2, deployed)
+    ├── /i/*       ──►  imgproxy     (Phase 2, deployed — image transforms)
     ├── /products/* ──►  cove-product (Phase 3)
     └── /users/*   ──►  cove-user    (Phase 3)
 ```
@@ -61,6 +62,7 @@ The cluster runs on a single-node K3s machine (AMD Ryzen 9600X, 64 GB RAM). Ever
 | External Secrets Operator | Syncs GCP Secret Manager → K8s Secrets | `external-secrets` |
 | CloudNativePG (CNPG) | Manages Postgres `Cluster` CRDs | `cnpg-system` |
 | Garage | S3-compatible object storage (`cove-media`, `postgres-backups`, `loki` buckets) | `garage` |
+| imgproxy | On-the-fly image resizing and re-encoding from Garage S3 sources | `cove-staging` / `cove-prod` |
 | kube-prometheus-stack | Prometheus + Grafana + Alertmanager | `monitoring` |
 | Loki + Alloy | Log aggregation (Alloy tails pod logs → Loki, 14d retention) | `monitoring` |
 | Cloudflare Tunnel | Exposes `api.coveapp.dev` → cluster without open ports | `cloudflare-tunnel` |
@@ -90,8 +92,8 @@ danicajiao/cove                 ← all source code and docs
 │   └── web/                    ← (planned)
 │
 ├── services/
-│   ├── cove-api/               ← cove-api gateway service (Phase 1)
-│   ├── cove-image/             ← cove-image service (Phase 2)
+│   ├── cove-api/               ← cove-api gateway service (Phase 1, deployed)
+│   ├── cove-image/             ← cove-image service (Phase 2, deployed)
 │   ├── cove-product/           ← cove-product service (Phase 3)
 │   └── cove-user/              ← cove-user service (Phase 3)
 │
@@ -137,10 +139,16 @@ build-cove-api: ## Build the cove-api Docker image
         -t cove-api:$(COMMIT_SHA) \
         services/cove-api/
 
-build-all: build-cove-api ## Build Docker images for all services
+build-cove-image: ## Build the cove-image Docker image
+    docker build \
+        --build-arg COMMIT_SHA=$(COMMIT_SHA) \
+        -t cove-image:$(COMMIT_SHA) \
+        services/cove-image/
+
+build-all: build-cove-api build-cove-image ## Build Docker images for all services
 ```
 
-As `cove-image`, `cove-product`, and `cove-user` land in later phases, each gets its own `build-cove-<service>` target wired into `build-all`.
+As `cove-product` and `cove-user` land in Phase 3, each gets its own `build-cove-<service>` target wired into `build-all`.
 
 This avoids the significant setup cost of a polyglot build system (Bazel, etc.) while keeping the door open — if build times become a problem as the repo grows, the groundwork is already in place to adopt one.
 
@@ -154,8 +162,8 @@ Services drop the `-svc` suffix. The pod, K8s Service, and image name are all th
 
 | Service | What it does | Phase |
 |---|---|---|
-| `cove-api` | BFF gateway — validates Firebase token, routes to backend services | Phase 1 |
-| `cove-image` | Image upload, resizing, CDN delivery via Garage | Phase 2 |
+| `cove-api` | BFF gateway — validates Firebase token, routes to backend services | Phase 1 (deployed) |
+| `cove-image` | Image upload (`POST /images`), signed-URL serving (`GET /images/{filename}/url`), normalization to WebP, content-addressed storage in Garage | Phase 2 (deployed) |
 | `cove-product` | Product catalog, categories, search | Phase 3 |
 | `cove-user` | User profiles, follows, producer accounts | Phase 3 |
 
@@ -338,12 +346,15 @@ Each phase is independently shippable. The iOS app is updated incrementally — 
 - iOS app routes all cove-api calls through `CoveAPIClient`; Firebase SDK still used directly for Auth, Firestore, and Storage
 - Smoke test: `CoveAPIClient.shared.health()` returns a `HealthResponse` with `status == "ok"`
 
-### Phase 2 — Image service
+### Phase 2 — Image service ✅ complete
 
-- Deploy `cove-image` to `cove-staging`
-- Handles image uploads, resizing, and delivery from Garage `cove-media` bucket
-- iOS app calls `api.coveapp.dev/images/*` instead of Firebase Storage
-- Firebase Storage retired for new uploads
+- `cove-image` deployed to `cove-staging` and `cove-prod`
+- `POST /images` — accepts JPEG/PNG/WebP, normalizes to WebP quality 90, strips EXIF (including GPS), stores content-addressed object in Garage `cove-media` bucket (`images/<sha256>.webp`)
+- `GET /images/{filename}/url` — generates a short-lived HMAC-SHA256 signed imgproxy URL (1 hr TTL); interim mechanism until `cove-product` embeds pre-signed URLs in Phase 3
+- `cove-api` proxies `/images/*` to `cove-image` and `/i/*` to imgproxy
+- iOS app loads all images via `CoveAPIClient.imageURL(filename:width:height:)` through the `ImageRepository` protocol; `CoveAPIImageRepository` is the active implementation
+- Firebase Storage fully retired; `FirebaseStorage` unlinked from the iOS Xcode target
+- Firestore `products.defaultImageURL` and `brands.imageURL` now store Garage keys (`images/<sha256>.webp`) instead of `gs://` URLs
 
 ### Phase 3 — Data services
 

--- a/docs/HOMELAB_COVE_LAYOUT.md
+++ b/docs/HOMELAB_COVE_LAYOUT.md
@@ -20,7 +20,7 @@ homelab/
 │   ├── gaming/
 │   │   └── minecraft/                    # separate tenant, not Cove
 │   └── cove/
-│       ├── base/                         # cove-api (Phase 1); cove-product, cove-user, cove-image land in Phases 2-3
+│       ├── base/                         # cove-api (Phase 1, deployed); cove-image + imgproxy (Phase 2, deployed); cove-product, cove-user in Phase 3
 │       └── overlays/
 │           ├── staging/                  # → cove-staging namespace
 │           └── prod/                     # → cove-prod namespace
@@ -57,12 +57,13 @@ Backend services live in the `danicajiao/cove` monorepo under `services/cove-<na
 
 | Service | Path in `danicajiao/cove` | Phase | Sub-issue |
 |---|---|---|---|
-| `cove-api` | `services/cove-api/` | 1 (shipped) | [danicajiao/cove#229](https://github.com/danicajiao/cove/issues/229) |
-| `cove-image` | `services/cove-image/` | 2 | [danicajiao/cove#238](https://github.com/danicajiao/cove/issues/238) |
+| `cove-api` | `services/cove-api/` | 1 (deployed) | [danicajiao/cove#229](https://github.com/danicajiao/cove/issues/229) |
+| `cove-image` | `services/cove-image/` | 2 (deployed) | [danicajiao/cove#238](https://github.com/danicajiao/cove/issues/238) |
+| `imgproxy` | cluster platform component (no source in this repo) | 2 (deployed) | — |
 | `cove-product` | `services/cove-product/` | 3 | [danicajiao/cove#250](https://github.com/danicajiao/cove/issues/250) |
 | `cove-user` | `services/cove-user/` | 3 | [danicajiao/cove#250](https://github.com/danicajiao/cove/issues/250) |
 
-`cove-api` shipped in Phase 1; the remaining services are added under the same convention as each phase begins.
+`cove-api` shipped in Phase 1. `cove-image` and `imgproxy` shipped in Phase 2. The remaining services are added under the same convention as each phase begins.
 
 ## Runbooks
 

--- a/docs/IOS_APP_ARCHITECTURE.md
+++ b/docs/IOS_APP_ARCHITECTURE.md
@@ -23,8 +23,8 @@ This document covers the Cove iOS app's architecture — how it's structured, ho
 Cove uses **MVVM (Model-View-ViewModel)** with SwiftUI. State is managed through a combination of `@StateObject`, `@EnvironmentObject`, and `@Published` properties.
 
 The app talks to two separate backends:
-- **Firebase** — Auth (sign-in), Firestore (structured data), Cloud Storage (images). Accessed directly through the Firebase iOS SDK.
-- **cove-api gateway** — the custom K3s-hosted backend. All calls go through `CoveAPIClient`, which is generated from the gateway's OpenAPI spec.
+- **Firebase** — Auth (sign-in) and Firestore (structured data). Accessed directly through the Firebase iOS SDK. Firebase Storage has been retired as of Phase 2.
+- **cove-api gateway** — the custom K3s-hosted backend. All calls go through `CoveAPIClient`, which is generated from the gateway's OpenAPI spec. Image loading now goes through this path via `CoveAPIImageRepository`.
 
 ---
 
@@ -158,11 +158,13 @@ Firebase SDK                        cove-api gateway
 (Google-managed infrastructure)     (K3s homelab, Cloudflare Tunnel)
 
 FirebaseAuth  ─────────────────►  Auth token issuance only
-FirebaseFirestore ─────────────►  Structured data (Phase 1–2 only; Firestore retired in Phase 3)
-FirebaseStorage ───────────────►  Images (Phase 1–2 only; retired in Phase 2)
+FirebaseFirestore ─────────────►  Structured data (Phase 2; Firestore retired in Phase 3)
+FirebaseStorage ───────────────►  (retired as of Phase 2 — unlinked from Xcode target)
 
                                   CoveAPIClient ──────────────────►  cove-api
-                                  (all new gateway calls go here)
+                                  (all gateway calls go here,
+                                   including image loading via
+                                   CoveAPIImageRepository)
 ```
 
 ### APIEnvironment
@@ -272,6 +274,30 @@ When a new route is added to cove-api:
 
 ---
 
+### ImageRepository — protocol and active implementation
+
+Image loading is abstracted behind the `ImageRepository` protocol. All views access it through the SwiftUI environment; `CoveApp` injects the concrete implementation at the root.
+
+```swift
+// Protocol — key-based: takes the Garage object key directly
+protocol ImageRepository {
+    func imageURL(for key: String) async throws -> URL
+}
+
+// Injection at the app root (CoveApp.swift)
+ContentView()
+    .environment(\.imageRepository, CoveAPIImageRepository())
+```
+
+**`CoveAPIImageRepository`** is the active implementation. It:
+1. Strips the `images/` prefix from the Garage key to get the bare filename
+2. Calls `CoveAPIClient.shared.imageURL(filename:width:height:)` — the `GET /images/{filename}/url` gateway endpoint
+3. Returns the signed imgproxy URL ready for `AsyncImage`
+
+`FirebaseImageRepository` was removed in Phase 2. There are no remaining references to Firebase Storage in the iOS codebase.
+
+---
+
 ## Product Type System
 
 Products in Firestore share a common `categoryId` field. The app uses this to decode into the correct Swift type at runtime.
@@ -334,16 +360,18 @@ if categoryId == ProductTypes.coffee.rawValue {
 products/{productId}
   ├── categoryId: String          // Maps to ProductTypes enum
   ├── defaultPrice: Float
-  ├── defaultImageURL: String     // Firebase Storage URL
+  ├── defaultImageURL: String     // Garage object key, e.g. "images/<sha256>.webp"
   ├── productDetailsId: String    // Foreign key to product_details
   ├── isFavorite: Bool?           // Set client-side after favorites query
   ├── createdAt: Timestamp
   └── info: { ... }              // Type-specific nested object
 ```
 
+Note: `defaultImageURL` previously held a Firebase Storage `gs://` URL. As of Phase 2 it holds a Garage object key (`images/<sha256>.webp`). The same key format applies to `brands.imageURL`.
+
 ### Image Loading
 
-Product images are stored in Firebase Storage. `ProductCardView` fetches them asynchronously via `Storage.storage().reference(forURL:).getData(maxSize:)`, storing the result in a `@State var uiImage`. No caching library is used — images re-fetch on each view appearance.
+Product images are loaded via the `ImageRepository` protocol injected into the SwiftUI environment. All image-loading views (`ProductCardView`, `ProductRowView`, `ProductDetailView`, `HomeView` brand logos) call `imageRepository.imageURL(for:)` with the Garage object key from Firestore, then pass the resulting signed URL to `AsyncImage`. Firebase Storage is no longer used.
 
 ---
 

--- a/docs/MEDIA_ARCHITECTURE.md
+++ b/docs/MEDIA_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Media Architecture
 
-> **Status:** Planned — built in Phase 2 alongside `cove-image`. v1 covers product images only; videos and documents are deferred. The bucket `cove-media` is already provisioned in Garage.
+> **Status:** Phase 2 complete. `cove-image` is deployed and handling image uploads and signed-URL delivery. The full variant-serving pipeline (imgproxy + Cloudflare CDN) and the Postgres `product.media` table are Phase 3 work — those sections document the target design. v1 covers product images only; videos and documents are deferred.
 
 ## Contents
 
@@ -31,6 +31,18 @@ Every product in Cove has at least one image, and most have a small gallery. Tho
 - Stay safe from URL abuse without breaking how `<img>` and `AsyncImage` work
 
 This doc describes the system that delivers all of that. For the broader data model — including the polymorphic `media` table and product/brand/storefront schema — see [Marketplace Architecture](MARKETPLACE_ARCHITECTURE.md); for Postgres mechanics see [Postgres Primer](POSTGRES_PRIMER.md).
+
+---
+
+## Phase 2 signed-URL endpoint — lifecycle
+
+`cove-image` exposes `GET /images/{filename}/url`, which returns a short-lived HMAC-SHA256 signed imgproxy URL (1 hr TTL). This is the endpoint the iOS app calls today via `CoveAPIClient.imageURL(filename:width:height:)`.
+
+**Phase 2 role:** interim mechanism — lets the iOS app fetch images before `cove-product` exists to embed signed URLs in its responses.
+
+**Phase 3 onwards:** `cove-product` will generate and embed pre-signed variant URLs directly in product list and detail responses. iOS will stop calling `GET /images/{filename}/url` for day-to-day image loading; the signed URL will be available in the response payload alongside the product data.
+
+**Ongoing role:** the endpoint stays deployed and useful for vendor-facing preview flows — e.g., preview a just-uploaded image before it is associated with a product.
 
 ---
 
@@ -263,7 +275,7 @@ Vendors upload once; the server handles everything that needs to be identical ac
 | Minimum dimensions | 2000 × 2000 | Need clean downscale to `xl` (3200) without upscaling artifacts on retina displays |
 | Maximum dimensions | 8000 × 8000 | Cap imgproxy memory/CPU per transformation |
 | Maximum file size | 20 MB | Generous for high-quality phone or DSLR shots |
-| Accepted formats | JPEG, PNG, WebP, HEIC | HEIC is iPhone's default; accepting it removes friction for vendors |
+| Accepted formats | JPEG, PNG, WebP | HEIC support is deferred (see "What's deferred" below) |
 | Aspect ratio | Any (documented preference: square or 4:3 for catalog browsing) | Server `fill`-crops to square variants regardless |
 
 These are returned in a structured error response when violated so the client can show a useful message ("Image must be at least 2000×2000 pixels").
@@ -273,23 +285,23 @@ These are returned in a structured error response when violated so the client ca
 After accepting the upload, `cove-image` runs the bytes through libvips before writing to Garage:
 
 ```
-1. Decode source format            (handles HEIC, JPEG, PNG, WebP)
+1. Decode source format            (handles JPEG, PNG, WebP — govips/libvips)
 2. Auto-rotate from EXIF flag      (phone photos often have rotation set)
 3. Strip EXIF metadata             (privacy: removes GPS coordinates; size win)
-4. Convert color space to sRGB     (consistency across devices and imgproxy reads)
-5. Re-encode as WebP, quality 90   (high-fidelity, compact)
-6. Compute SHA-256 of resulting bytes
-7. Write to Garage as cove-media/<sha256>.webp
-8. Return { key, width, height } to the caller
+4. Re-encode as WebP, quality 90   (high-fidelity, compact)
+5. Compute SHA-256 of resulting bytes
+6. Write to Garage as images/<sha256>.webp  (bucket: cove-media)
+7. Return { key, width, height } to the caller
 ```
 
 Why each step matters:
 
 - **Strip EXIF** — phone photos embed GPS coordinates by default. Without this, every product image leaks the vendor's location.
 - **Auto-rotate** — phones store the image with the sensor's native orientation and a separate rotation flag. Without rotating during decode, half the uploads display sideways.
-- **sRGB color space** — Adobe RGB and P3 sources render with shifted colors when imgproxy converts them at delivery time. Normalizing once on upload avoids surprises.
 - **WebP quality 90** — visually lossless; ~40-60% smaller than the equivalent JPEG. Cheap storage win.
 - **Content-addressed key** — if a vendor uploads the same image twice (different products, same source photo), Garage stores one object. If a vendor mid-upload retries, we don't pollute storage with half-written objects.
+
+Note: sRGB color-space normalization and HEIC acceptance are deferred to a future iteration (see "What's deferred").
 
 ### Associating with a product
 
@@ -487,6 +499,8 @@ This stays out of the hot path entirely.
 
 These are real future requirements but explicitly out of scope for v1:
 
+- **HEIC input** — iPhone's default capture format. govips supports it when built with HEIC support; defer until vendor upload UX exists and we can test end-to-end.
+- **sRGB color-space normalization** — Adobe RGB and P3 sources render with shifted colors when imgproxy converts at delivery time. Normalizing on upload avoids surprises; deferred because most phone uploads are already sRGB.
 - **Videos** — would need a separate pipeline (HLS/DASH transcoding, manifest generation, per-bandwidth renditions). No imgproxy equivalent for video that fits this stack cleanly.
 - **Documents** (vendor certifications, ingredient lists as PDFs) — would use Option D (token-protected, no transformation, just signed-URL serving).
 - **Watermarking** — imgproxy supports it; not a v1 product requirement.

--- a/services/README.md
+++ b/services/README.md
@@ -4,14 +4,18 @@ Backend services live here, using the `cove-<name>` convention (e.g.
 `services/cove-api/`). The sibling `apps/` directory is reserved for client
 applications (the iOS app today, a web client later).
 
-The first backend service, the `cove-api` gateway, ships in Phase 1 and lives at
-[`cove-api/`](cove-api/). Later phases add `cove-image`, `cove-product`, and
-`cove-user` under the same `services/cove-<name>/` convention.
+| Service | Directory | Phase | Status |
+|---|---|---|---|
+| `cove-api` | [`cove-api/`](cove-api/) | 1 | Deployed |
+| `cove-image` | [`cove-image/`](cove-image/) | 2 | Deployed |
+| `cove-product` | `cove-product/` | 3 | Planned |
+| `cove-user` | `cove-user/` | 3 | Planned |
 
 Each service owns its own `Dockerfile` and is built and pushed by the
-`ci-services.yml` GitHub Actions workflow on changes to its path. The OpenAPI
-spec for `cove-api` is the source of truth for request/response shapes and lives
-at `services/cove-api/api/openapi.yaml`.
+`ci-services.yml` GitHub Actions workflow on changes to its path. OpenAPI specs
+are the source of truth for request/response shapes:
+- `cove-api`: `services/cove-api/api/openapi.yaml`
+- `cove-image`: `services/cove-image/api/openapi.yaml`
 
 See [docs/BACKEND_INFRASTRUCTURE.md](../docs/BACKEND_INFRASTRUCTURE.md) for the
 full service map, naming convention, and migration phases.


### PR DESCRIPTION
## Summary

- Marks Phase 2 complete in `docs/BACKEND_INFRASTRUCTURE.md` with accurate endpoint and service details
- Updates `docs/MEDIA_ARCHITECTURE.md`: correct status, add signed-URL endpoint lifecycle note (Phase 2 interim role, Phase 3 retirement, ongoing vendor preview use), fix accepted image formats and normalization pipeline steps to match shipped code
- Updates `docs/IOS_APP_ARCHITECTURE.md`: retire FirebaseStorage, document `ImageRepository` protocol + `CoveAPIImageRepository`, update Firestore image key format (Garage key replaces `gs://`)
- Updates `docs/HOMELAB_COVE_LAYOUT.md`: mark `cove-image` and imgproxy as deployed
- Updates `services/README.md`: adds `cove-image` row with status table
- Updates `CLAUDE.md`: fixes repo layout, backend table, and project overview to remove stale Firebase Storage references
- Adds mandatory docs-audit sub-issue rule and dependency-wiring rule to both `github-project-planner` agent files

## Test plan

- [x] Verify no references to `apps/image/`, `FirebaseStorage` (as active), or `cove-ios` remain in docs
- [x] Confirm Phase 2 marked complete in `docs/BACKEND_INFRASTRUCTURE.md`
- [x] Confirm normalization pipeline in `docs/MEDIA_ARCHITECTURE.md` matches `services/cove-image/internal/normalize/normalize.go`
- [x] Confirm `ImageRepository` section in `docs/IOS_APP_ARCHITECTURE.md` matches `CoveAPIImageRepository` behavior described in issue

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
