### PR TITLE
Align issue-label taxonomy with branch prefixes

### DIFF
--- a/.claude/agents/github-project-planner.md
+++ b/.claude/agents/github-project-planner.md
@@ -247,7 +247,7 @@ Every issue needs a **type label**. Most sub-issues need an **area label**. Epic
 - `ui/ux` — front-end design work, whether visual layouts or motion/animation. Signals that a design exists or is needed and governs the implementation. An iOS screen or animation with a design is tagged `ios, ui/ux`; iOS work with no design surface (networking, repositories) is just `ios`.
 - `testing` — unit, integration, or test-suite work
 
-**Rules**: Never combine `feature` + `enhancement`. Apply `ui/ux` to a sub-issue when a front-end design governs the work — record the design asset in the issue's Technical Notes (a Figma frame URL for visual work, the Rive animation spec for motion work). An `ios + ui/ux` sub-issue is the signal the `swiftui-engineer` agent is ready to pick it up. **The `ui/ux` label is design-tool-agnostic by design — there is no separate `figma` or `rive` label.** Naming a tool in a label couples the taxonomy to a vendor; the tool belongs in Technical Notes, not the label. If the design tool ever changes, no labels go stale.
+**Rules**: Never combine `feature` + `enhancement`. Apply `ui/ux` to a sub-issue when a front-end design governs the work — record the design asset in the issue's Technical Notes (a Figma frame URL for visual work, the Rive animation spec for motion work). The `swiftui-engineer` agent picks up `ios` sub-issues; when one also carries `ui/ux`, it matches the implementation to that design. **The `ui/ux` label is design-tool-agnostic by design — there is no separate `figma` or `rive` label.** Naming a tool in a label couples the taxonomy to a vendor; the tool belongs in Technical Notes, not the label. If the design tool ever changes, no labels go stale.
 
 **Examples**:
 - Epic: Auth System → `epic, feature, security`
@@ -285,7 +285,7 @@ The issues you create are the top of a multi-agent pipeline. Once an issue is cr
 
 **How sub-issues flow downstream:**
 
-- `ios + ui/ux` sub-issues → picked up by the `swiftui-engineer` agent, which reads the issue body (and the design frame URL in its Technical Notes) as its spec, implements the view in a worktree, and creates a PR that closes the issue
+- `ios` sub-issues → picked up by the `swiftui-engineer` agent, which reads the issue body as its spec (and, when the issue carries `ui/ux`, the design frame URL in its Technical Notes), implements the work in a worktree, and creates a PR that closes the issue
 - The branch the agent works on is named after the issue: `feature/<issue-id>-<short-description>`
 - Sub-issue PRs target the **integration branch** (`feature/<epic-id>-<description>`), not `main` — include the integration branch name in each sub-issue's Technical Notes so agents know where to target
 - The PR description contains `Closes #<issue-id>`, which auto-closes the issue on merge

--- a/.claude/agents/github-project-planner.md
+++ b/.claude/agents/github-project-planner.md
@@ -43,7 +43,7 @@ Sub-Issues:
 1. "<Title>" [labels: feature, backend]
    - What: ...
    - Why this is a separate task: ...
-2. "<Title>" [labels: feature, ui/ux]
+2. "<Title>" [labels: feature, ios, ui/ux]
    ...
 
 Codebase Notes:
@@ -56,8 +56,8 @@ Before asking for final confirmation, check whether any sub-issues are tagged `u
 
 > "Is there an existing Figma design for **[sub-issue title]**? If so, share the frame link and it will be embedded in the issue for the UI implementer."
 
-- If the user provides a link → add the `figma` label to that sub-issue and record the URL
-- If the user says no design exists yet → create the issue without the `figma` label; it can be added later when a design is ready
+- If the user provides a link → keep the `ui/ux` label and record the frame URL in the issue's Technical Notes
+- If the user says no design exists yet → keep `ui/ux` to mark that a design governs this work, and note in the body that the design is pending; the URL is added later when ready
 - If the user provides a link for some but not all UI sub-issues → handle each independently
 
 ### 5. Confirm
@@ -145,7 +145,7 @@ Review and update all documentation affected by this epic so it accurately refle
 - Blocked by #<all other leaf sub-issue numbers>
 ```
 
-Add the `docs` label. Do **not** add `ui/ux`, `backend`, or other area labels to this sub-issue.
+Add the `docs` label. Do **not** add `ios`, `backend`, `ui/ux`, or other area labels to this sub-issue.
 
 ---
 
@@ -236,20 +236,27 @@ Every issue needs a **type label**. Most sub-issues need an **area label**. Epic
 | Category | Labels |
 |----------|--------|
 | Epic (required on epics) | `epic` |
-| Type (pick one) | `feature`, `enhancement`, `bug`, `maintenance`, `docs`, `security` |
-| Area (pick 1+) | `ui/ux`, `backend`, `testing` |
-| Asset (optional) | `figma`, `rive` |
+| Type (pick one) | `feature`, `enhancement`, `bugfix`, `chore`, `docs`, `security` |
+| Area (pick 1+) | `ios`, `backend`, `ui/ux`, `testing` |
 | Meta (sparingly) | `good first issue`, `help wanted`, `question`, `wontfix` |
 
-**Rules**: Never combine `feature` + `enhancement`. Add `figma` to a `ui/ux` sub-issue only when the user has provided a Figma frame link — it signals the design exists and the issue is ready for the `swiftui-engineer` agent. Do not add `figma` speculatively. Add `rive` when a Rive animation asset is required.
+**Area labels:**
+
+- `ios` — any and all work on the iOS platform: views, view models, components, networking, repositories, anything under `apps/ios/`
+- `backend` — Go services, APIs, data persistence, business logic under `services/`
+- `ui/ux` — front-end design work, whether visual layouts or motion/animation. Signals that a design exists or is needed and governs the implementation. An iOS screen or animation with a design is tagged `ios, ui/ux`; iOS work with no design surface (networking, repositories) is just `ios`.
+- `testing` — unit, integration, or test-suite work
+
+**Rules**: Never combine `feature` + `enhancement`. Apply `ui/ux` to a sub-issue when a front-end design governs the work — record the design asset in the issue's Technical Notes (a Figma frame URL for visual work, the Rive animation spec for motion work). An `ios + ui/ux` sub-issue is the signal the `swiftui-engineer` agent is ready to pick it up. **The `ui/ux` label is design-tool-agnostic by design — there is no separate `figma` or `rive` label.** Naming a tool in a label couples the taxonomy to a vendor; the tool belongs in Technical Notes, not the label. If the design tool ever changes, no labels go stale.
 
 **Examples**:
 - Epic: Auth System → `epic, feature, security`
-- Implement Firebase Auth → `feature, backend, security`
-- Build checkout UI → `feature, ui/ux, figma`
-- Fix cart total bug → `bug, backend`
-- Add ViewModel unit tests → `maintenance, testing`
-- Payment confirmation animation → `feature, ui/ux, rive`
+- Implement Firebase Auth (iOS) → `feature, ios, security`
+- Implement cove-item discovery endpoint → `feature, backend`
+- Build checkout UI → `feature, ios, ui/ux`
+- Fix cart total bug (iOS) → `bugfix, ios`
+- Add ViewModel unit tests → `chore, ios, testing`
+- Payment confirmation animation → `feature, ios, ui/ux`
 
 ---
 
@@ -278,7 +285,7 @@ The issues you create are the top of a multi-agent pipeline. Once an issue is cr
 
 **How sub-issues flow downstream:**
 
-- `ui/ux + figma` sub-issues → picked up by the `swiftui-engineer` agent, which reads the issue body as its spec, implements the view in a worktree, and creates a PR that closes the issue
+- `ios + ui/ux` sub-issues → picked up by the `swiftui-engineer` agent, which reads the issue body (and the design frame URL in its Technical Notes) as its spec, implements the view in a worktree, and creates a PR that closes the issue
 - The branch the agent works on is named after the issue: `feature/<issue-id>-<short-description>`
 - Sub-issue PRs target the **integration branch** (`feature/<epic-id>-<description>`), not `main` — include the integration branch name in each sub-issue's Technical Notes so agents know where to target
 - The PR description contains `Closes #<issue-id>`, which auto-closes the issue on merge
@@ -289,7 +296,7 @@ The issues you create are the top of a multi-agent pipeline. Once an issue is cr
 The issue body is the agent's only spec inside the worktree. Write it accordingly:
 
 - **Acceptance Criteria** must be complete and checkable — the agent ticks these off before creating the PR
-- **Technical Notes** must include the Figma frame URL (for `ui/ux + figma` issues), relevant file paths, and patterns to follow
+- **Technical Notes** must include the Figma frame URL (for `ui/ux` issues), relevant file paths, and patterns to follow
 - **Dependencies** must name the blocking issue number — the agent uses this to know whether to stub data or wait
 
 Vague issues produce vague implementations. The more precise the issue, the better the agent's output.

--- a/.claude/agents/swiftui-engineer.md
+++ b/.claude/agents/swiftui-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: swiftui-engineer
-description: Implements SwiftUI views from Figma designs. Use when a GitHub issue is labeled ui/ux and figma, or when a Figma URL is provided with a request to build a screen or component. Reads the design from Figma, explores existing codebase patterns, and produces production-ready SwiftUI code matched to the design.
+description: Implements SwiftUI views from Figma designs. Use when a GitHub issue is labeled ios and ui/ux, or when a Figma URL is provided with a request to build a screen or component. Reads the design from Figma, explores existing codebase patterns, and produces production-ready SwiftUI code matched to the design.
 ---
 
 # SwiftUI Engineer

--- a/.claude/agents/swiftui-engineer.md
+++ b/.claude/agents/swiftui-engineer.md
@@ -1,16 +1,16 @@
 ---
 name: swiftui-engineer
-description: Implements SwiftUI views from Figma designs. Use when a GitHub issue is labeled ios and ui/ux, or when a Figma URL is provided with a request to build a screen or component. Reads the design from Figma, explores existing codebase patterns, and produces production-ready SwiftUI code matched to the design.
+description: Implements iOS app work in Swift/SwiftUI — views, view models, components, and supporting code. Use for any issue labeled ios. When the issue also carries ui/ux (or a Figma URL is provided), reads the Figma design and matches the implementation to it. Explores existing codebase patterns and produces production-ready code.
 ---
 
 # SwiftUI Engineer
 
-You are a senior iOS engineer and expert Figma user. You bridge the gap between Figma designs and production SwiftUI code — with pixel fidelity to the design and full conformance to the project's existing patterns and conventions.
+You are a senior iOS engineer and expert Figma user. You implement iOS app work in Swift/SwiftUI — views, view models, components, and the code that supports them — with full conformance to the project's existing patterns and conventions. When an issue includes a design (it carries `ui/ux` or a Figma URL), you bridge Figma to production SwiftUI with pixel fidelity.
 
 ## Non-Negotiables
 
-- **Always call `get_design_context` before writing any code** — never implement from metadata alone
-- **Always call `get_variable_defs` to extract design tokens** — map Figma variables to project color/font tokens
+- **When the issue includes a design, always call `get_design_context` before writing any UI code** — never implement from metadata alone
+- **When implementing a design, always call `get_variable_defs` to extract design tokens** — map Figma variables to project color/font tokens
 - **Always explore the codebase before writing** — find existing components, colors, fonts, and patterns to reuse
 - **Never invent design tokens** — map every color, font, and spacing value to the project's existing tokens. The authoritative reference is `docs/DESIGN_SYSTEM.md` — read it before implementing any UI
 - **Never create a ViewModel unless the issue explicitly asks for one** — check if an existing ViewModel covers the data needs first
@@ -47,6 +47,8 @@ git branch -m feature/<issue-number>-<short-description>
 Do this before any file writes. The branch name is how the dependency gate hook identifies which issue is active — if the branch isn't renamed first, the hook can't check dependencies.
 
 ### 2. Get the Design from Figma
+
+> **Design issues only.** If the issue has no design surface — no `ui/ux` label or Figma URL (e.g. networking, repositories, view-model logic) — skip this section and implement directly from the acceptance criteria and existing codebase patterns.
 
 Call these in parallel:
 

--- a/.github/agents/github-project-planner.agent.md
+++ b/.github/agents/github-project-planner.agent.md
@@ -184,7 +184,7 @@ Every issue needs a **type label**. Most sub-issues need an **area label**. Epic
 - `ui/ux` — front-end design work, whether visual layouts or motion/animation. Signals a design exists or is needed and governs the implementation. An iOS screen or animation with a design is tagged `ios, ui/ux`; iOS work with no design surface (networking, repositories) is just `ios`.
 - `testing` — unit, integration, or test-suite work
 
-**Rules**: Never combine `feature` + `enhancement`. Apply `ui/ux` when a front-end design governs the work, and record the design asset in the issue's Technical Notes (a Figma frame URL for visual work, the Rive animation spec for motion work) — an `ios + ui/ux` sub-issue is the signal the `swiftui-engineer` agent is ready to pick it up. **The `ui/ux` label is design-tool-agnostic by design — there is no separate `figma` or `rive` label.** Naming a tool in a label couples the taxonomy to a vendor; the tool belongs in Technical Notes, not the label. Verify unfamiliar labels exist with `github/get_label` before using them.
+**Rules**: Never combine `feature` + `enhancement`. Apply `ui/ux` when a front-end design governs the work, and record the design asset in the issue's Technical Notes (a Figma frame URL for visual work, the Rive animation spec for motion work) — the `swiftui-engineer` agent picks up `ios` sub-issues, and when one also carries `ui/ux` it matches the implementation to that design. **The `ui/ux` label is design-tool-agnostic by design — there is no separate `figma` or `rive` label.** Naming a tool in a label couples the taxonomy to a vendor; the tool belongs in Technical Notes, not the label. Verify unfamiliar labels exist with `github/get_label` before using them.
 
 ---
 

--- a/.github/agents/github-project-planner.agent.md
+++ b/.github/agents/github-project-planner.agent.md
@@ -45,7 +45,7 @@ Sub-Issues:
 1. "<Title>" [labels: feature, backend]
    - What: ...
    - Why this is a separate task: ...
-2. "<Title>" [labels: feature, ui/ux]
+2. "<Title>" [labels: feature, ios, ui/ux]
    ...
 
 Codebase Notes:
@@ -93,7 +93,7 @@ Review and update all documentation affected by this epic so it accurately refle
 - Blocked by #<all other leaf sub-issue numbers>
 ```
 
-Add the `docs` label. Do **not** add `ui/ux`, `backend`, or other area labels to this sub-issue.
+Add the `docs` label. Do **not** add `ios`, `backend`, `ui/ux`, or other area labels to this sub-issue.
 
 ---
 
@@ -173,12 +173,18 @@ Every issue needs a **type label**. Most sub-issues need an **area label**. Epic
 | Category | Labels |
 |----------|--------|
 | Epic (required on epics) | `epic` |
-| Type (pick one) | `feature`, `enhancement`, `bug`, `maintenance`, `docs`, `security` |
-| Area (pick 1+) | `ui/ux`, `backend`, `testing` |
-| Asset (optional) | `figma`, `rive` |
+| Type (pick one) | `feature`, `enhancement`, `bugfix`, `chore`, `docs`, `security` |
+| Area (pick 1+) | `ios`, `backend`, `ui/ux`, `testing` |
 | Meta (sparingly) | `good first issue`, `help wanted`, `question`, `wontfix` |
 
-**Rules**: Never combine `feature` + `enhancement`. If design or animation assets are needed before implementation can start, add `figma` or `rive` to signal the dependency. Verify unfamiliar labels exist with `github/get_label` before using them.
+**Area labels:**
+
+- `ios` — any and all work on the iOS platform: views, view models, components, networking, repositories, anything under `apps/ios/`
+- `backend` — Go services, APIs, data persistence, business logic under `services/`
+- `ui/ux` — front-end design work, whether visual layouts or motion/animation. Signals a design exists or is needed and governs the implementation. An iOS screen or animation with a design is tagged `ios, ui/ux`; iOS work with no design surface (networking, repositories) is just `ios`.
+- `testing` — unit, integration, or test-suite work
+
+**Rules**: Never combine `feature` + `enhancement`. Apply `ui/ux` when a front-end design governs the work, and record the design asset in the issue's Technical Notes (a Figma frame URL for visual work, the Rive animation spec for motion work) — an `ios + ui/ux` sub-issue is the signal the `swiftui-engineer` agent is ready to pick it up. **The `ui/ux` label is design-tool-agnostic by design — there is no separate `figma` or `rive` label.** Naming a tool in a label couples the taxonomy to a vendor; the tool belongs in Technical Notes, not the label. Verify unfamiliar labels exist with `github/get_label` before using them.
 
 ---
 

--- a/.github/agents/swiftui-engineer.agent.md
+++ b/.github/agents/swiftui-engineer.agent.md
@@ -1,18 +1,18 @@
 ---
 name: SwiftUI Engineer
-description: 'Implements SwiftUI views from Figma designs. Use when a GitHub issue is labeled ios and ui/ux, or when a Figma URL is provided with a request to build a screen or component. Reads the design from Figma, explores existing codebase patterns, and produces production-ready SwiftUI code matched to the design.'
+description: 'Implements iOS app work in Swift/SwiftUI — views, view models, components, and supporting code. Use for any issue labeled ios. When the issue also carries ui/ux (or a Figma URL is provided), reads the Figma design and matches the implementation to it. Explores existing codebase patterns and produces production-ready code.'
 tools: [execute/runInTerminal, read/readFile, edit/createFile, edit/editFiles, search/fileSearch, search/textSearch, search/codebase, github/issue_read, github/issue_write, github/create_pull_request, github/create_branch, github/push_files]
 argument-hint: 'Provide a GitHub issue number or Figma URL. Example: "Implement issue #142", "Build the profile screen from figma.com/design/..."'
 ---
 
 # SwiftUI Engineer
 
-You are a senior iOS engineer and expert Figma user. You bridge the gap between Figma designs and production SwiftUI code — with pixel fidelity to the design and full conformance to the project's existing patterns and conventions.
+You are a senior iOS engineer and expert Figma user. You implement iOS app work in Swift/SwiftUI — views, view models, components, and the code that supports them — with full conformance to the project's existing patterns and conventions. When an issue includes a design (it carries `ui/ux` or a Figma URL), you bridge Figma to production SwiftUI with pixel fidelity.
 
 ## Non-Negotiables
 
-- **Always call `get_design_context` before writing any code** — never implement from metadata alone
-- **Always call `get_variable_defs` to extract design tokens** — map Figma variables to project color/font tokens
+- **When the issue includes a design, always call `get_design_context` before writing any UI code** — never implement from metadata alone
+- **When implementing a design, always call `get_variable_defs` to extract design tokens** — map Figma variables to project color/font tokens
 - **Always explore the codebase before writing** — find existing components, colors, fonts, and patterns to reuse
 - **Never invent design tokens** — map every color, font, and spacing value to the project's existing tokens. The authoritative reference is `docs/DESIGN_SYSTEM.md` — read it before implementing any UI
 - **Never create a ViewModel unless the issue explicitly asks for one** — check if an existing ViewModel covers the data needs first
@@ -43,6 +43,8 @@ git branch -m feature/<issue-number>-<short-description>
 Do this before any file writes. The branch name is how the dependency gate hook identifies which issue is active — if the branch isn't renamed first, the hook can't check dependencies.
 
 ### 2. Get the Design from Figma
+
+> **Design issues only.** If the issue has no design surface — no `ui/ux` label or Figma URL (e.g. networking, repositories, view-model logic) — skip this section and implement directly from the acceptance criteria and existing codebase patterns.
 
 Call these in parallel (requires Figma MCP):
 

--- a/.github/agents/swiftui-engineer.agent.md
+++ b/.github/agents/swiftui-engineer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: SwiftUI Engineer
-description: 'Implements SwiftUI views from Figma designs. Use when a GitHub issue is labeled ui/ux and figma, or when a Figma URL is provided with a request to build a screen or component. Reads the design from Figma, explores existing codebase patterns, and produces production-ready SwiftUI code matched to the design.'
+description: 'Implements SwiftUI views from Figma designs. Use when a GitHub issue is labeled ios and ui/ux, or when a Figma URL is provided with a request to build a screen or component. Reads the design from Figma, explores existing codebase patterns, and produces production-ready SwiftUI code matched to the design.'
 tools: [execute/runInTerminal, read/readFile, edit/createFile, edit/editFiles, search/fileSearch, search/textSearch, search/codebase, github/issue_read, github/issue_write, github/create_pull_request, github/create_branch, github/push_files]
 argument-hint: 'Provide a GitHub issue number or Figma URL. Example: "Implement issue #142", "Build the profile screen from figma.com/design/..."'
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,14 +64,14 @@ The `<REPO>` prefix is always ALL CAPS and identifies which repo's issue tracker
 |---|---|
 | `feature/` | New screens or user-facing functionality |
 | `enhancement/` | Improvements to existing features |
-| `bug/` | Bug fixes |
+| `bugfix/` | Bug fixes |
 | `docs/` | Documentation-only changes |
-| `chore/` | Maintenance, config, tooling |
+| `chore/` | Refactoring, cleanup, config, tooling |
 
 Examples — with issue:
 - `feature/COVE-137-profile-view-model`
 - `enhancement/COVE-66-improve-tab-navigation`
-- `bug/COVE-3-fix-login-crash`
+- `bugfix/COVE-3-fix-login-crash`
 
 Examples — no issue (off-cycle fixes):
 - `docs/update-readme`
@@ -324,6 +324,6 @@ The `github-project-planner` agent should wire these after creating sub-issues, 
 
 | Sub-issue labels | Handled by |
 |---|---|
-| `ui/ux` + `figma` | `swiftui-engineer` |
+| `ios` + `ui/ux` | `swiftui-engineer` |
 | `docs` | `documentation-maintainer` |
 | planning / epics | `github-project-planner` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,6 @@ The `github-project-planner` agent should wire these after creating sub-issues, 
 
 | Sub-issue labels | Handled by |
 |---|---|
-| `ios` + `ui/ux` | `swiftui-engineer` |
+| `ios` (matches a Figma design when also `ui/ux`) | `swiftui-engineer` |
 | `docs` | `documentation-maintainer` |
 | planning / epics | `github-project-planner` |

--- a/README.md
+++ b/README.md
@@ -128,11 +128,24 @@ The `<REPO>` prefix is ALL CAPS and identifies the issue tracker — always `COV
 |---|---|
 | `feature/` | New screens or user-facing functionality |
 | `enhancement/` | Improvements to existing features |
-| `bug/` | Bug fixes |
+| `bugfix/` | Bug fixes |
 | `docs/` | Documentation-only changes |
-| `chore/` | Maintenance, config, tooling |
+| `chore/` | Refactoring, cleanup, config, tooling |
 
-Examples: `feature/COVE-21-favorites-view`, `bug/COVE-3-fix-login-crash`, `docs/update-readme`
+Examples: `feature/COVE-21-favorites-view`, `bugfix/COVE-3-fix-login-crash`, `docs/update-readme`
+
+### Issue Labels
+
+Every issue gets a **type** label and most get one or more **area** labels. Area labels drive which agent picks the issue up.
+
+| Area label | Scope |
+|---|---|
+| `ios` | Any work on the iOS platform — views, view models, components, networking, repositories (everything under `apps/ios/`) |
+| `backend` | Go services, APIs, data persistence (everything under `services/`) |
+| `ui/ux` | Front-end design work — visual layouts or motion/animation. Marks that a design governs the work; an iOS screen or animation with a design is `ios` + `ui/ux` |
+| `testing` | Unit, integration, or test-suite work |
+
+An `ios` + `ui/ux` issue is the signal for the `swiftui-engineer` agent. The `ui/ux` label is design-tool-agnostic — there are no tool-specific labels (no `figma`, no `rive`); the specific design asset goes in the issue's Technical Notes. See `.claude/agents/github-project-planner.md` for the full taxonomy (type and meta labels).
 
 ### Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Every issue gets a **type** label and most get one or more **area** labels. Area
 | `ui/ux` | Front-end design work — visual layouts or motion/animation. Marks that a design governs the work; an iOS screen or animation with a design is `ios` + `ui/ux` |
 | `testing` | Unit, integration, or test-suite work |
 
-An `ios` + `ui/ux` issue is the signal for the `swiftui-engineer` agent. The `ui/ux` label is design-tool-agnostic — there are no tool-specific labels (no `figma`, no `rive`); the specific design asset goes in the issue's Technical Notes. See `.claude/agents/github-project-planner.md` for the full taxonomy (type and meta labels).
+The `swiftui-engineer` agent picks up any `ios` issue; when one also carries `ui/ux`, it matches the implementation to the design. The `ui/ux` label is design-tool-agnostic — there are no tool-specific labels (no `figma`, no `rive`); the specific design asset goes in the issue's Technical Notes. See `.claude/agents/github-project-planner.md` for the full taxonomy (type and meta labels).
 
 ### Pull Requests
 


### PR DESCRIPTION
## Summary

Reconciles the GitHub issue-label set with the branch-prefix vocabulary so the two no longer drift, removes tool-coupled labels, and clarifies which agent owns iOS issues. No code changes — labels were applied on GitHub via `gh`; this PR updates the docs that describe the taxonomy and routing.

## Label changes (already applied on GitHub)

**Area labels**
- ➕ Created `ios` — all iOS-platform work (views, view models, components, networking, repositories; everything under `apps/ios/`)
- ✏️ `ui/ux` redefined as front-end design work — visual layouts **or** motion/animation. Now absorbs the two removed asset labels below.
- 🗑️ Removed `figma` and `rive` — tool-coupled labels. The specific design asset (Figma frame URL, Rive spec) now lives in the issue's **Technical Notes**, so nothing goes stale if the design tool changes.
- `backend` is now scoped to Go services only.
- The **Asset** label category is dropped entirely.

**Type labels** (now 1:1 with branch prefixes)
- ✏️ `bug` → `bugfix` (and branch prefix `bug/` → `bugfix/`)
- ✏️ `maintenance` → `chore` (matches the existing `chore/` branch prefix)

Renames preserve the label on all existing issues (7 `bugfix`, ~30 `chore`). All 22 closed `figma` issues and the single closed `rive` issue were the only users of the deleted labels.

## Agent routing

The `swiftui-engineer` agent owns **any** `ios` issue — not only `ios + ui/ux`. The `ui/ux` label is an additional signal that a design exists to match, not a precondition. The agent's Figma workflow (the `get_design_context`/`get_variable_defs` steps) is now conditional: a non-design iOS issue (networking, repositories, view-model logic) skips straight to implementing from acceptance criteria and codebase patterns.

## Resulting aligned scheme

| Concept | Branch prefix | Type label |
|---|---|---|
| New functionality | `feature/` | `feature` |
| Improvement | `enhancement/` | `enhancement` |
| Bug fix | `bugfix/` | `bugfix` |
| Housekeeping | `chore/` | `chore` |
| Docs | `docs/` | `docs` |
| Security | — | `security` |

Area labels: `ios`, `backend`, `ui/ux`, `testing`. Routing: any `ios` issue → `swiftui-engineer` (matches a Figma design when the issue also carries `ui/ux`).

## Files changed
- `.claude/agents/github-project-planner.md` + `.github/agents/github-project-planner.agent.md` — Label System taxonomy, rules, examples, Figma-link flow, downstream routing
- `.claude/agents/swiftui-engineer.md` + `.github/agents/swiftui-engineer.agent.md` — trigger is any `ios` issue; Figma workflow made conditional on a design being present
- `CLAUDE.md` — issue-to-agent routing table + branch-prefix table
- `README.md` — new **Issue Labels** subsection + branch-prefix table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
