### PR TITLE
Move role creation out of migrations into CNPG bootstrap

### DIFF
--- a/docs/DATABASE_MIGRATIONS.md
+++ b/docs/DATABASE_MIGRATIONS.md
@@ -1,0 +1,215 @@
+# Database Migrations
+
+Operational runbook for running, debugging, and managing schema migrations against the `cove-db` CNPG cluster.
+
+## Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Connecting to the cluster](#connecting-to-the-cluster)
+- [Running migrations](#running-migrations)
+- [Role management](#role-management)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+Cove uses [golang-migrate](https://github.com/golang-migrate/migrate) for schema migrations. Each service owns its own migration directory:
+
+| Service | Migrations path | Schemas owned |
+|---|---|---|
+| `cove-item` | `services/cove-item/migrations/` | `directory`, `catalog` |
+| `cove-user` | `services/cove-user/migrations/` | `profile` |
+
+Migrations are plain SQL files in numbered pairs (`000001_name.up.sql` / `000001_name.down.sql`). golang-migrate tracks the current version in a `schema_migrations` table it manages in the `public` schema of the `cove` database.
+
+**cove-item migrations must run before cove-user** — the `profile` schema has cross-schema foreign keys into `catalog` and `directory`.
+
+---
+
+## Prerequisites
+
+**Install the migrate CLI:**
+```bash
+brew install golang-migrate
+```
+
+**Verify kubectl is connected:**
+```bash
+kubectl get nodes
+```
+
+---
+
+## Connecting to the cluster
+
+The `cove-db` cluster is not publicly exposed — it only accepts connections from inside the cluster. Use `kubectl port-forward` to tunnel the Postgres port to your local machine.
+
+**Staging:**
+```bash
+kubectl port-forward -n cove-staging svc/cove-db-rw 5432:5432
+```
+
+**Prod (use a different local port to avoid conflict if both are open):**
+```bash
+kubectl port-forward -n cove-prod svc/cove-db-rw 5433:5432
+```
+
+Leave the port-forward running in a separate terminal while you run migrations.
+
+**Getting the app user password:**
+```bash
+# staging
+kubectl get secret -n cove-staging cove-db-app \
+  -o jsonpath='{.data.password}' | base64 -d
+
+# prod
+kubectl get secret -n cove-prod cove-db-app \
+  -o jsonpath='{.data.password}' | base64 -d
+```
+
+---
+
+## Running migrations
+
+Run from the root of the `cove` repo with the port-forward active.
+
+### Apply all pending migrations
+
+```bash
+# 1. cove-item (directory + catalog schemas)
+migrate \
+  -path services/cove-item/migrations \
+  -database "postgres://app:<password>@localhost:5432/cove?sslmode=disable" \
+  up
+
+# 2. cove-user (profile schema) — run after cove-item
+migrate \
+  -path services/cove-user/migrations \
+  -database "postgres://app:<password>@localhost:5432/cove?sslmode=disable" \
+  up
+```
+
+### Roll back one step
+
+```bash
+migrate \
+  -path services/cove-item/migrations \
+  -database "postgres://app:<password>@localhost:5432/cove?sslmode=disable" \
+  down 1
+```
+
+### Check current version
+
+```bash
+migrate \
+  -path services/cove-item/migrations \
+  -database "postgres://app:<password>@localhost:5432/cove?sslmode=disable" \
+  version
+```
+
+### Verify applied schema (via psql)
+
+```bash
+# List schemas
+kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c "\dn"
+
+# List tables in a schema
+kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c "\dt directory.*"
+kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c "\dt catalog.*"
+kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c "\dt profile.*"
+```
+
+---
+
+## Role management
+
+### Why roles are not in migration files
+
+`CREATE ROLE` is an instance-level superuser operation. The `app` user that golang-migrate connects as is a regular database user with no `CREATEROLE` privilege — attempting it produces:
+
+```
+error: migration failed: permission denied to create role
+```
+
+Roles are managed separately via the CNPG cluster bootstrap (`postInitApplicationSQL` in `apps/cove/base/cove-db/cluster.yaml` in the homelab repo), which runs as superuser at cluster creation time.
+
+**The boundary:**
+
+| Object | Managed by | Privilege required |
+|---|---|---|
+| Roles (`cove_item`, `cove_user`) | CNPG `postInitApplicationSQL` | Superuser |
+| Extensions (`postgis`, `ltree`) | CNPG `postInitApplicationSQL` | Superuser |
+| Schemas, tables, grants | golang-migrate | App user |
+
+### Accessing the superuser
+
+CNPG's `postgres` superuser uses **peer authentication** inside the pod — no password is needed when connecting from within the same process. Use `kubectl exec` to connect:
+
+```bash
+kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove
+```
+
+### Manually provisioning roles (existing clusters)
+
+`postInitApplicationSQL` only runs at cluster creation time. For existing clusters, roles must be created once manually:
+
+```bash
+kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c "
+DO \$\$ BEGIN CREATE ROLE cove_item WITH LOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;
+DO \$\$ BEGIN CREATE ROLE cove_user WITH LOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;
+"
+```
+
+Verify:
+```bash
+kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -c "\du"
+```
+
+Role passwords are managed via ESO → GCP Secret Manager and set with `ALTER ROLE` — they are never stored in migration files.
+
+---
+
+## Troubleshooting
+
+### Dirty migration state
+
+If a migration fails partway through, golang-migrate marks the version as `dirty` and refuses to run until it is resolved:
+
+```
+error: Dirty database version 1. Fix and force version.
+```
+
+**Check the state:**
+```bash
+kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove \
+  -c "SELECT * FROM schema_migrations;"
+```
+
+**Fix options:**
+
+If the migration failed cleanly (Postgres rolled back the transaction — most DDL in Postgres is transactional), the database is actually in the prior good state. Clear the dirty record and rerun:
+
+```bash
+# Clear the dirty record (safe if the transaction rolled back)
+kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove \
+  -c "DELETE FROM schema_migrations;"
+
+# Then rerun
+migrate -path services/cove-item/migrations -database "..." up
+```
+
+If the migration partially applied (some statements committed before the failure), use `migrate force <version>` to mark the version as clean, then manually fix the inconsistency before rerunning:
+
+```bash
+migrate -path services/cove-item/migrations -database "..." force 1
+```
+
+### Permission denied errors
+
+If migrate errors with `permission denied`, check which operation failed:
+
+- **`permission denied to create role`** — role creation is in a migration file; it must move to the CNPG bootstrap. See [Role management](#role-management).
+- **`permission denied for schema`** — the `app` user is missing a `GRANT USAGE` on that schema. Check that the setup migration applied cleanly.
+- **`permission denied for table`** — the `app` user is missing table-level grants. Check that the relevant migration applied cleanly.

--- a/services/cove-item/migrations/000001_setup.down.sql
+++ b/services/cove-item/migrations/000001_setup.down.sql
@@ -4,8 +4,8 @@ ALTER ROLE cove_user  RESET search_path;
 REVOKE USAGE ON SCHEMA catalog, directory FROM cove_item;
 REVOKE USAGE ON SCHEMA catalog, directory FROM cove_user;
 
-DROP ROLE IF EXISTS cove_item;
-DROP ROLE IF EXISTS cove_user;
-
-DROP SCHEMA IF EXISTS catalog  CASCADE;
+DROP SCHEMA IF EXISTS catalog   CASCADE;
 DROP SCHEMA IF EXISTS directory CASCADE;
+
+-- Roles are NOT dropped here — they are cluster-level objects managed by
+-- the CNPG bootstrap. Dropping them requires superuser access.

--- a/services/cove-item/migrations/000001_setup.up.sql
+++ b/services/cove-item/migrations/000001_setup.up.sql
@@ -6,22 +6,11 @@ CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE SCHEMA IF NOT EXISTS directory;
 CREATE SCHEMA IF NOT EXISTS catalog;
 
--- Service roles. Passwords are managed externally via Kubernetes secrets
--- (ESO → GCP Secret Manager) and set with ALTER ROLE after provisioning.
--- cove_directory is intentionally omitted — the directory schema exists
--- but cove-item owns it for v1 reads until cove-directory ships.
-DO $$ BEGIN
-    CREATE ROLE cove_item WITH LOGIN;
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
-
-DO $$ BEGIN
-    CREATE ROLE cove_user WITH LOGIN;
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+-- Roles (cove_item, cove_user) are created in the CNPG cluster bootstrap
+-- via postInitApplicationSQL. They exist before migrations run.
 
 -- Schema-level grants
-GRANT USAGE ON SCHEMA catalog  TO cove_item;
+GRANT USAGE ON SCHEMA catalog   TO cove_item;
 GRANT USAGE ON SCHEMA directory TO cove_item;
 
 GRANT USAGE ON SCHEMA catalog, directory TO cove_user;


### PR DESCRIPTION
## Summary

- Removes `CREATE ROLE` and `DROP ROLE` from `services/cove-item/migrations/000001_setup` — roles are cluster-level superuser operations that the `app` user cannot execute
- Adds `docs/DATABASE_MIGRATIONS.md` — operations runbook covering how to run migrations, role management architecture, superuser access via `kubectl exec`, and dirty migration troubleshooting

## Root cause

Running `migrate up` for the first time failed with:

```
error: migration failed: permission denied to create role
```

`CREATE ROLE` is an instance-level superuser operation. The `app` user golang-migrate connects as is a regular database user with no `CREATEROLE` privilege — a deliberate CNPG security boundary.

The fix is an architectural correction: roles belong in the CNPG cluster bootstrap (`postInitApplicationSQL`), not in application migrations. The correct boundary is:

| Object | Managed by | Privilege required |
|---|---|---|
| Roles (`cove_item`, `cove_user`) | CNPG `postInitApplicationSQL` | Superuser |
| Extensions (`postgis`, `ltree`) | CNPG `postInitApplicationSQL` | Superuser |
| Schemas, tables, grants | golang-migrate | App user |

The homelab change is in danicajiao/homelab#52 (merged).

## For existing clusters

`postInitApplicationSQL` only runs at cluster creation time. Roles must be created once manually — see `docs/DATABASE_MIGRATIONS.md §Role management` for the commands.

## Test plan

- [x] `migrate up` applies cleanly against staging with no permission errors
- [x] `migrate down` rolls back cleanly
- [x] `kubectl exec ... psql -c "\du"` shows `cove_item` and `cove_user` in both namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
