### PR TITLE
Remove ALTER ROLE from migrations — requires superuser

### DIFF
--- a/docs/DATABASE_MIGRATIONS.md
+++ b/docs/DATABASE_MIGRATIONS.md
@@ -151,20 +151,26 @@ CNPG's `postgres` superuser uses **peer authentication** inside the pod — no p
 kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove
 ```
 
+### Superuser-only operations
+
+Both `CREATE ROLE` and `ALTER ROLE` require superuser privileges. Neither can run in migrations (the `app` user has neither `CREATEROLE` nor `ADMIN` on the service roles). Both live in `postInitApplicationSQL` in the homelab cluster.yaml.
+
 ### Manually provisioning roles (existing clusters)
 
-`postInitApplicationSQL` only runs at cluster creation time. For existing clusters, roles must be created once manually:
+`postInitApplicationSQL` only runs at cluster creation time. For existing clusters, roles and search paths must be created once manually:
 
 ```bash
-kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c "
+kubectl exec -n <namespace> cove-db-1 -- psql -U postgres -d cove -c "
 DO \$\$ BEGIN CREATE ROLE cove_item WITH LOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;
 DO \$\$ BEGIN CREATE ROLE cove_user WITH LOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;
+ALTER ROLE cove_item SET search_path = catalog, directory, public;
+ALTER ROLE cove_user  SET search_path = profile, public;
 "
 ```
 
 Verify:
 ```bash
-kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -c "\du"
+kubectl exec -n <namespace> cove-db-1 -- psql -U postgres -c "\du"
 ```
 
 Role passwords are managed via ESO → GCP Secret Manager and set with `ALTER ROLE` — they are never stored in migration files.

--- a/docs/DATABASE_MIGRATIONS.md
+++ b/docs/DATABASE_MIGRATIONS.md
@@ -168,9 +168,14 @@ ALTER ROLE cove_user  SET search_path = profile, public;
 "
 ```
 
-Verify:
+Verify roles exist and `search_path` defaults are set:
 ```bash
+# Lists roles and attributes (does not show search_path)
 kubectl exec -n <namespace> cove-db-1 -- psql -U postgres -c "\du"
+
+# Confirms search_path is set — search_path lives in pg_db_role_setting, not \du
+kubectl exec -n <namespace> cove-db-1 -- psql -U postgres -d cove -c \
+  "SELECT rolname, setconfig FROM pg_roles r LEFT JOIN pg_db_role_setting s ON r.oid = s.setrole WHERE rolname IN ('cove_item', 'cove_user');"
 ```
 
 Role passwords are managed via ESO → GCP Secret Manager and set with `ALTER ROLE` — they are never stored in migration files.

--- a/services/cove-item/migrations/000001_setup.down.sql
+++ b/services/cove-item/migrations/000001_setup.down.sql
@@ -1,11 +1,8 @@
-ALTER ROLE cove_item RESET search_path;
-ALTER ROLE cove_user  RESET search_path;
-
 REVOKE USAGE ON SCHEMA catalog, directory FROM cove_item;
 REVOKE USAGE ON SCHEMA catalog, directory FROM cove_user;
 
 DROP SCHEMA IF EXISTS catalog   CASCADE;
 DROP SCHEMA IF EXISTS directory CASCADE;
 
--- Roles are NOT dropped here — they are cluster-level objects managed by
--- the CNPG bootstrap. Dropping them requires superuser access.
+-- Roles and search_path defaults are cluster-level objects managed by
+-- the CNPG bootstrap — not dropped or reset here.

--- a/services/cove-item/migrations/000001_setup.up.sql
+++ b/services/cove-item/migrations/000001_setup.up.sql
@@ -6,15 +6,12 @@ CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE SCHEMA IF NOT EXISTS directory;
 CREATE SCHEMA IF NOT EXISTS catalog;
 
--- Roles (cove_item, cove_user) are created in the CNPG cluster bootstrap
--- via postInitApplicationSQL. They exist before migrations run.
+-- Roles and their search_path defaults are managed in the CNPG cluster
+-- bootstrap (postInitApplicationSQL) — both CREATE ROLE and ALTER ROLE
+-- require superuser, which the app user does not have.
 
--- Schema-level grants
+-- Schema-level grants — app owns the schemas it creates, so GRANT is permitted.
 GRANT USAGE ON SCHEMA catalog   TO cove_item;
 GRANT USAGE ON SCHEMA directory TO cove_item;
 
 GRANT USAGE ON SCHEMA catalog, directory TO cove_user;
-
--- Default search paths
-ALTER ROLE cove_item SET search_path = catalog, directory, public;
-ALTER ROLE cove_user  SET search_path = profile, public;


### PR DESCRIPTION
## Summary

- Removes `ALTER ROLE ... SET search_path` from `000001_setup.up.sql` — like `CREATE ROLE`, it requires superuser and cannot run as the `app` migration user
- Removes the corresponding `RESET search_path` lines from `000001_setup.down.sql`
- Updates `docs/DATABASE_MIGRATIONS.md` to document that both `CREATE ROLE` and `ALTER ROLE` are superuser-only operations, and to include the manual provisioning commands for existing clusters

## Root cause

The first migration run moved `CREATE ROLE` to CNPG bootstrap (danicajiao/cove#346 / danicajiao/homelab#52), but `ALTER ROLE SET search_path` was left in the migration file. The `app` user has neither `CREATEROLE` nor `ADMIN` on the service roles, so this also requires superuser. The companion homelab PR adds both `ALTER ROLE` lines to `postInitApplicationSQL`.

## Companion PR

danicajiao/homelab#53 — adds `ALTER ROLE cove_item` and `ALTER ROLE cove_user` to `cove-db` bootstrap

## Test plan

- [x] Port-forward staging cluster and run `migrate up` against both `cove-item` and `cove-user` migration sets — should complete without permission errors
- [x] Verify roles exist: `kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -c "\du"`
- [x] Verify `search_path` is set — `\du` does not show role settings, query `pg_db_role_setting` directly:
  ```
  kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c \
    "SELECT rolname, setconfig FROM pg_roles r LEFT JOIN pg_db_role_setting s ON r.oid = s.setrole WHERE rolname IN ('cove_item', 'cove_user');"
  ```

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
