### PR TITLE
Document PR format, AC verification, and post-merge comment workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,21 @@
-This PR {short description}:
-* Closes {Issue number or link}
+<!--
+  If this PR is linked to an issue, include the ## Issue section below and
+  replace the placeholder. Remove the ## Issue section for off-cycle changes
+  that have no associated issue.
+-->
+
+## Issue
+
+[COVE-N](https://github.com/danicajiao/cove/issues/N)
+
+## Summary
+
+<!-- What changed and why? -->
+
+## Test plan
+
+- [ ] 
+
+<!-- For issue-linked PRs: verify all Acceptance Criteria are met before opening. -->
+
+Closes #N

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ## Issue
 
-* danicajiao/cove#N
+* <owner>/<repo>#N
 
 ## Summary
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ## Issue
 
-[COVE-N](https://github.com/danicajiao/cove/issues/N)
+* danicajiao/cove#N
 
 ## Summary
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,52 @@ This rule applies to every agent **and** to the main session. If the MCP propaga
 - Open a PR targeting the epic's integration branch (provided in your task prompt) or `main` if there is no epic
 - Include `Closes #<issue-id>` in the PR description
 
+### Pull request format
+
+**Standard sections (in order):**
+
+```markdown
+## Issue        ← link to related issue; omit for off-cycle PRs (no issue number in branch)
+## Summary      ← what changed and why
+## Test plan    ← verification checklist
+
+Closes #N       ← at the bottom; omit for off-cycle PRs
+```
+
+**Issue link — required when the branch name contains `<REPO>-<ISSUE-NO>`:**
+
+Parse the issue number from the branch name and include an `## Issue` section at the very top of the PR body. Off-cycle branches (no issue number) omit this section entirely.
+
+```markdown
+## Issue
+
+[COVE-318](https://github.com/danicajiao/cove/issues/318)
+```
+
+### Pre-review AC check
+
+Before opening a PR, fetch the associated issue and verify every Acceptance Criteria item is satisfied by the changes. Determine the issue number from the branch name (`<REPO>-<ISSUE-NO>`).
+
+```bash
+gh issue view <issue-number> --repo danicajiao/cove --json body -q .body
+```
+
+Do not open the PR if any AC item is unmet — finish the work first. Skip this step for off-cycle branches that have no associated issue.
+
+### Post-merge AC comment
+
+After the user confirms a PR is merged, fetch the issue's AC, verify each item against the work that was done, and post a comment on the issue summarizing the result.
+
+```bash
+# Fetch AC
+gh issue view <issue-number> --repo danicajiao/cove --json body -q .body
+
+# Post the comment
+gh issue comment <issue-number> --repo danicajiao/cove --body-file /tmp/ac-comment.md
+```
+
+The comment should list each AC item with ✅ or ❌ and a brief note on how it was verified. Skip for off-cycle PRs with no associated issue.
+
 ### Pull request and issue linking
 
 GitHub's `Closes #<issue-id>` keyword in the PR body is the standard linking mechanism. When the PR targets `main` it auto-closes the issue and populates the Development sidebar automatically. When targeting an integration branch, the keyword is documentation only — the formal Development sidebar link requires a manual step in the GitHub UI (gear icon in the Development section of the PR).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,26 +287,46 @@ This rule applies to every agent **and** to the main session. If the MCP propaga
 - Open a PR targeting the epic's integration branch (provided in your task prompt) or `main` if there is no epic
 - Include `Closes #<issue-id>` in the PR description
 
-### Pull request format
+### Pull request body format
 
-**Standard sections (in order):**
+Every PR body written to a `--body-file` must follow this layout. The `## Issue` section is required whenever the branch name contains `<REPO>-<ISSUE-NO>`; omit it for off-cycle branches with no associated issue.
 
-```markdown
-## Issue        ← link to related issue; omit for off-cycle PRs (no issue number in branch)
-## Summary      ← what changed and why
-## Test plan    ← verification checklist
-
-Closes #N       ← at the bottom; omit for off-cycle PRs
-```
-
-**Issue link — required when the branch name contains `<REPO>-<ISSUE-NO>`:**
-
-Parse the issue number from the branch name and include an `## Issue` section at the very top of the PR body. Off-cycle branches (no issue number) omit this section entirely.
-
-```markdown
+```bash
+cat > /tmp/pr-body.md << 'EOF'
 ## Issue
 
 * danicajiao/cove#318
+
+## Summary
+
+<!-- What changed and why -->
+
+## Test plan
+
+- [ ] ...
+
+Closes #318
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+
+gh pr create --title "..." --body-file /tmp/pr-body.md
+```
+
+**Off-cycle PR (no issue)** — omit `## Issue` and `Closes #N`:
+
+```bash
+cat > /tmp/pr-body.md << 'EOF'
+## Summary
+
+<!-- What changed and why -->
+
+## Test plan
+
+- [ ] ...
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
 ```
 
 ### Pre-review AC check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,7 +306,7 @@ Parse the issue number from the branch name and include an `## Issue` section at
 ```markdown
 ## Issue
 
-[COVE-318](https://github.com/danicajiao/cove/issues/318)
+* danicajiao/cove#318
 ```
 
 ### Pre-review AC check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,7 @@ Every PR body written to a `--body-file` must follow this layout. The `## Issue`
 cat > /tmp/pr-body.md << 'EOF'
 ## Issue
 
-* danicajiao/cove#318
+* <owner>/<repo>#<issue-number>
 
 ## Summary
 
@@ -305,7 +305,7 @@ cat > /tmp/pr-body.md << 'EOF'
 
 - [ ] ...
 
-Closes #318
+Closes #<issue-number>
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF


### PR DESCRIPTION
## Summary

Three additions to `CLAUDE.md` to tighten up the PR workflow for agents and human contributors:

1. **PR format** — when a branch name includes `<REPO>-<ISSUE-NO>`, the PR must open with an `## Issue` section linking to it. Off-cycle branches (no issue number) omit the section. Documents the standard section order: Issue → Summary → Test plan → `Closes #N`.

2. **Pre-review AC check** — before opening a PR, fetch the associated issue and verify every Acceptance Criteria item is met. Don't open the PR against unmet AC.

3. **Post-merge AC comment** — after the user confirms a PR is merged, post a comment on the issue listing each AC item with ✅/❌ and a brief verification note.

Also updates `.github/pull_request_template.md` from the old bare two-liner to match the documented format, so human contributors get the right scaffolding when opening PRs on GitHub.com.

## Test plan

- [x] Review new sections in CLAUDE.md read clearly and cover all three cases (issue-linked PR, off-cycle PR, post-merge)
- [x] PR template renders correctly on GitHub when opening a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
