### PR TITLE
Seed signal taxonomy and port Firestore data to Postgres

### DIFF
--- a/docs/MARKETPLACE_ARCHITECTURE.md
+++ b/docs/MARKETPLACE_ARCHITECTURE.md
@@ -11,6 +11,7 @@
 - [Single Postgres cluster, schemas per service](#single-postgres-cluster-schemas-per-service)
 - [The trust signal system](#the-trust-signal-system)
 - [Composite trust scoring](#composite-trust-scoring)
+- [Personalized ranking via signal-preference alignment](#personalized-ranking-via-signal-preference-alignment)
 - [Geospatial: the local availability gate](#geospatial-the-local-availability-gate)
 - [Categories and facets](#categories-and-facets)
 - [Database schema](#database-schema)
@@ -225,6 +226,107 @@ result_trust_score(product, maker, storefront) =
 **Materialize** `maker.trust_score` and `storefront.trust_score` (recompute when their signals change — rare; for v1, computed once at seed time) and B-tree index them so the discovery `ORDER BY` is cheap. Add the product's own signals live.
 
 The brief's "rewards breadth and diversity of trust signals rather than any single credential" is a refinement of *how* the sum works — diminishing returns on stacking similar signals, a bonus for spanning categories — and the `maker.tier` (Individual Lister vs Verified Business) shifts the weighting (Individual Listers lean more on community vouching). **Start with flat additive weights**; tune the function later. This does not block the schema.
+
+---
+
+## Personalized ranking via signal-preference alignment
+
+> **Status: post-v1 ideation.** The schema scaffolding (`profile.interests`, `catalog.signals.weight`) is already in place. The preference→signal mapping and the boosted scoring formula are not yet implemented.
+
+### The problem
+
+Two users search for the same thing — "specialty coffee near me." One cares deeply about ethical supply chains; the other cares about environmental certifications. The flat trust score returns the same ranked list for both. Personalized ranking amplifies signals that match a user's stated values, surfacing more relevant results without changing the underlying verification system.
+
+### Signal dimensions
+
+B Corp is a holistic cert — it covers Workers, Community, Environment, Customers, and Governance. It is **not** an "ethical trading" signal specifically. Fair Trade is the most direct signal for ethical supply chains (fair prices to producers, no exploitative sourcing). Mapping user preferences to signals requires understanding what each signal actually certifies:
+
+| User preference | Most relevant signals | Partially relevant |
+|---|---|---|
+| Ethical trading / fair sourcing | `fair_trade` | `b_corp` (community/customers dimension) |
+| Environmental | `usda_organic`, `one_pct_planet` | `b_corp` (environment dimension) |
+| Supports workers / living wages | `living_wage` | `b_corp` (workers dimension) |
+| Community / local impact | `colorado_proud` | `b_corp` (community dimension), `one_pct_planet` |
+
+B Corp overlaps with many preferences because it is multi-dimensional. A user who says "I care about everything" gets the same boost from B Corp as someone who says "I care about environment" — until the mapping is made preference-specific.
+
+### Approach A — Preference → signal relevance table (recommended for v1 personalization)
+
+A lookup table maps each user preference tag to signal codes with a relevance weight (0–1). The personalized score replaces the flat `signal.weight` with `signal.weight × relevance`:
+
+```sql
+CREATE TABLE catalog.preference_signal_weights (
+    preference_tag  text    NOT NULL,  -- matches values in profile.interests
+    signal_code     text    NOT NULL REFERENCES catalog.signals(code),
+    relevance       numeric NOT NULL CHECK (relevance BETWEEN 0 AND 1),
+    PRIMARY KEY (preference_tag, signal_code)
+);
+
+-- Example rows
+INSERT INTO catalog.preference_signal_weights VALUES
+    ('ethical_trading', 'fair_trade',   1.0),
+    ('ethical_trading', 'b_corp',       0.7),
+    ('ethical_trading', 'one_pct_planet', 0.4),
+    ('environmental',   'usda_organic', 1.0),
+    ('environmental',   'one_pct_planet', 0.9),
+    ('environmental',   'b_corp',       0.8),
+    ('supports_workers','living_wage',  1.0),
+    ('supports_workers','b_corp',       0.6);
+```
+
+Scoring formula at query time:
+
+```sql
+-- Personalized trust score for a maker, given a user's preference tags
+SELECT
+    m.name,
+    SUM(s.weight * COALESCE(psw.relevance, 0)) AS personalized_score
+FROM directory.makers m
+JOIN catalog.entity_signals es ON es.maker_id = m.id AND es.status = 'verified'
+JOIN catalog.signals s ON s.id = es.signal_id
+LEFT JOIN catalog.preference_signal_weights psw
+    ON psw.signal_code = s.code
+    AND psw.preference_tag = ANY($user_preference_tags)
+WHERE m.id = $maker_id
+GROUP BY m.id;
+```
+
+Onyx Coffee Lab example with user preference `ethical_trading`:
+- B Corp (weight 3) × relevance 0.7 = **2.1** personalized score
+- If Onyx also had Fair Trade (weight 2) × relevance 1.0 = +2.0 → **4.1 total**
+
+### Approach B — Signal dimensions array (more scalable, no per-pair maintenance)
+
+Tag each signal with the values dimensions it covers. User preferences select dimensions; scoring is the overlap between user-selected dimensions and signal dimensions. New signals automatically fit when tagged correctly — no mapping table update needed.
+
+```sql
+ALTER TABLE catalog.signals ADD COLUMN dimensions text[] NOT NULL DEFAULT '{}';
+
+-- B Corp covers all five dimensions
+UPDATE catalog.signals SET dimensions = '{environmental, labor, community, governance, ethical_trading}' WHERE code = 'b_corp';
+UPDATE catalog.signals SET dimensions = '{ethical_trading, labor}' WHERE code = 'fair_trade';
+UPDATE catalog.signals SET dimensions = '{labor}'                   WHERE code = 'living_wage';
+UPDATE catalog.signals SET dimensions = '{environmental}'          WHERE code = 'usda_organic';
+UPDATE catalog.signals SET dimensions = '{environmental, community}' WHERE code = 'one_pct_planet';
+UPDATE catalog.signals SET dimensions = '{community}'              WHERE code = 'colorado_proud';
+```
+
+Tradeoff vs. Approach A: simpler to maintain, but loses the per-pair relevance granularity (you can't say "fair_trade is more directly 'ethical trading' than b_corp is").
+
+### How other companies handle this
+
+- **Good On You** (fashion sustainability app — closest analog to Cove): Rates brands on Labor, Environment, and Animal. Users can filter or sort by dimension. Simple tag-overlap scoring at small catalog scale — no ML.
+- **Etsy**: Tag matching + engagement signals. Personalization is additive on top of a base relevance score; explicit preferences seed it, behavior refines it.
+- **Spotify/Netflix**: Collaborative filtering — "users like you also liked X." Only meaningful once behavioral data exists (what makers users viewed, saved, purchased from). Overkill until Cove has that data.
+
+### Evolution path
+
+1. **Now (v1):** flat additive trust score — `SUM(signal.weight)` for verified signals. No preference amplification.
+2. **v1 personalization:** add `catalog.preference_signal_weights`; score the discovery query with `signal.weight × relevance` against `profile.interests`. The discovery query gains a `$user_preference_tags` param.
+3. **Behavioral blend:** add `profile.events` attention signals (item views, dwell time, saves) as implicit preference data. Blend explicit `profile.interests` weight + implicit engagement count.
+4. **Eventually:** ML ranking layer — collaborative filtering on the blended signal. Only worthwhile when the catalog and user base are large enough to produce meaningful co-engagement data.
+
+Steps 2–4 are additive — no existing tables change.
 
 ---
 
@@ -704,4 +806,5 @@ To reconcile before the Phase 3 epic is re-planned:
 - **Version 4.1** (May 2026) — **Terminology + individual-maker support.** `brand` → `maker` (covers a person or a company); the supply-side schema/service became `directory` / `cove-directory` (retiring the ambiguous "vendor"); `storefront` kept as the internal name with a `type` enum (shop/gallery/studio/market/taproom) and "Where to find it" as the consumer label; `tier` (Verified Business / Individual Lister) moved onto `maker`; added `operated_by_maker_id` for maker-run storefronts. Replaced the single `storefront_id` on items with a many-to-many `availability` join so one maker's item can be sold at many storefronts (studio + gallery + market) — the individual-artist case from the brief.
 - **Version 4.2** (May 2026) — **Category depth + personalization.** Capped v1 taxonomy at 3 levels (`root.mid.leaf`). Added homepage category cards with a two-phase personalization model (onboarding explicit interests → behavioral attention metrics). Added `profile.interests` and `profile.events` tables to the `profile` schema. Documented `ItemTypes.swift` replacement by API-driven categories. Expanded Open item 4 to cover `/categories`, `/recommendations/categories`, and `/users/me/events` endpoints.
 - **Version 4.3** (May 2026) — **item rename.** `product` → `item` throughout: entity name, `product` Postgres schema → `catalog`, `product.products` → `catalog.items`, `cove-product` service → `cove-item`, iOS types (`Product` protocol → `Item`, `ProductRepository` → `ItemRepository`, etc.). Column renames: `product_id` → `item_id` in `catalog.entity_signals`, `catalog.media`, `catalog.availability`, `profile.favorites`, `profile.events`.
+- **Version 4.5** (Jun 2026) — **Personalized ranking ideation.** Added "Personalized ranking via signal-preference alignment" section documenting the preference→signal mapping design (Approach A: `preference_signal_weights` table; Approach B: `signal_dimensions[]` on signals), the personalized scoring formula, signal dimension breakdown per preference tag, and the four-phase evolution path from flat additive scoring to collaborative filtering.
 - **Version 4.4** (May 2026) — **Category leaf enforcement.** Added `is_leaf boolean` to `catalog.categories`; four triggers enforce that items only reference leaf nodes and keep `is_leaf` accurate on insert/delete. v1 seed (242 nodes across 9 top-level categories) landed in migrations 004–006. Added [Category Taxonomy](CATEGORY_TAXONOMY.md) reference doc.

--- a/services/cove-item/migrations/000007_schema_enhancements.down.sql
+++ b/services/cove-item/migrations/000007_schema_enhancements.down.sql
@@ -1,0 +1,53 @@
+ALTER TABLE catalog.entity_signals
+    DROP COLUMN IF EXISTS verified_by,
+    DROP COLUMN IF EXISTS cert_expires_at,
+    DROP COLUMN IF EXISTS cert_number;
+
+-- Restore item_id FK to ON DELETE CASCADE (reverting the RESTRICT change)
+ALTER TABLE catalog.availability
+    DROP CONSTRAINT IF EXISTS availability_item_id_fkey;
+
+ALTER TABLE catalog.availability
+    ADD CONSTRAINT availability_item_id_fkey
+        FOREIGN KEY (item_id) REFERENCES catalog.items(id) ON DELETE CASCADE;
+
+DROP INDEX IF EXISTS catalog.availability_storefront_id_idx;
+
+ALTER TABLE catalog.availability
+    DROP COLUMN IF EXISTS is_active,
+    DROP COLUMN IF EXISTS listing_url,
+    DROP COLUMN IF EXISTS listing_source;
+
+ALTER TABLE catalog.signals
+    DROP COLUMN IF EXISTS is_active,
+    DROP COLUMN IF EXISTS has_expiry;
+
+DROP INDEX IF EXISTS directory.storefronts_is_active_idx;
+DROP INDEX IF EXISTS directory.storefronts_slug_idx;
+
+ALTER TABLE directory.storefronts
+    DROP COLUMN IF EXISTS updated_at,
+    DROP COLUMN IF EXISTS is_active,
+    DROP COLUMN IF EXISTS website_url,
+    DROP COLUMN IF EXISTS zip,
+    DROP COLUMN IF EXISTS state,
+    DROP COLUMN IF EXISTS city,
+    DROP COLUMN IF EXISTS slug;
+
+-- Note: restoring NOT NULL on address/location would fail if null rows exist.
+-- Only uncomment if staging has been rolled back cleanly:
+-- ALTER TABLE directory.storefronts ALTER COLUMN address  SET NOT NULL;
+-- ALTER TABLE directory.storefronts ALTER COLUMN location SET NOT NULL;
+
+DROP INDEX IF EXISTS directory.makers_is_active_idx;
+DROP INDEX IF EXISTS directory.makers_location_idx;
+DROP INDEX IF EXISTS directory.makers_slug_idx;
+
+ALTER TABLE directory.makers
+    DROP COLUMN IF EXISTS updated_at,
+    DROP COLUMN IF EXISTS is_active,
+    DROP COLUMN IF EXISTS location,
+    DROP COLUMN IF EXISTS zip,
+    DROP COLUMN IF EXISTS state,
+    DROP COLUMN IF EXISTS city,
+    DROP COLUMN IF EXISTS slug;

--- a/services/cove-item/migrations/000007_schema_enhancements.down.sql
+++ b/services/cove-item/migrations/000007_schema_enhancements.down.sql
@@ -46,6 +46,7 @@ DROP INDEX IF EXISTS directory.makers_slug_idx;
 ALTER TABLE directory.makers
     DROP COLUMN IF EXISTS updated_at,
     DROP COLUMN IF EXISTS is_active,
+    DROP COLUMN IF EXISTS website_url,
     DROP COLUMN IF EXISTS location,
     DROP COLUMN IF EXISTS zip,
     DROP COLUMN IF EXISTS state,

--- a/services/cove-item/migrations/000007_schema_enhancements.up.sql
+++ b/services/cove-item/migrations/000007_schema_enhancements.up.sql
@@ -1,12 +1,13 @@
 -- Enhance directory.makers: url-friendly slug, location, soft-delete, audit timestamp
 ALTER TABLE directory.makers
-    ADD COLUMN slug       text UNIQUE,
-    ADD COLUMN city       text,
-    ADD COLUMN state      text,
-    ADD COLUMN zip        text,
-    ADD COLUMN location   geography(Point, 4326),
-    ADD COLUMN is_active  boolean     NOT NULL DEFAULT true,
-    ADD COLUMN updated_at timestamptz NOT NULL DEFAULT now();
+    ADD COLUMN slug        text UNIQUE,
+    ADD COLUMN city        text,
+    ADD COLUMN state       text,
+    ADD COLUMN zip         text,
+    ADD COLUMN location    geography(Point, 4326),
+    ADD COLUMN website_url text,
+    ADD COLUMN is_active   boolean     NOT NULL DEFAULT true,
+    ADD COLUMN updated_at  timestamptz NOT NULL DEFAULT now();
 
 CREATE INDEX ON directory.makers (slug);
 CREATE INDEX ON directory.makers USING GIST (location);

--- a/services/cove-item/migrations/000007_schema_enhancements.up.sql
+++ b/services/cove-item/migrations/000007_schema_enhancements.up.sql
@@ -1,0 +1,66 @@
+-- Enhance directory.makers: url-friendly slug, location, soft-delete, audit timestamp
+ALTER TABLE directory.makers
+    ADD COLUMN slug       text UNIQUE,
+    ADD COLUMN city       text,
+    ADD COLUMN state      text,
+    ADD COLUMN zip        text,
+    ADD COLUMN location   geography(Point, 4326),
+    ADD COLUMN is_active  boolean     NOT NULL DEFAULT true,
+    ADD COLUMN updated_at timestamptz NOT NULL DEFAULT now();
+
+CREATE INDEX ON directory.makers (slug);
+CREATE INDEX ON directory.makers USING GIST (location);
+CREATE INDEX ON directory.makers (is_active) WHERE is_active = true;
+
+-- Enhance directory.storefronts: slug, structured location, soft-delete, audit timestamp.
+-- Drop NOT NULL on address and location — online storefronts have neither.
+ALTER TABLE directory.storefronts
+    ALTER COLUMN address  DROP NOT NULL,
+    ALTER COLUMN location DROP NOT NULL,
+    ADD COLUMN slug        text UNIQUE,
+    ADD COLUMN city        text,
+    ADD COLUMN state       text,
+    ADD COLUMN zip         text,
+    ADD COLUMN website_url text,
+    ADD COLUMN is_active   boolean     NOT NULL DEFAULT true,
+    ADD COLUMN updated_at  timestamptz NOT NULL DEFAULT now();
+
+CREATE INDEX ON directory.storefronts (slug);
+CREATE INDEX ON directory.storefronts (is_active) WHERE is_active = true;
+
+-- Enhance catalog.signals: expiry flag (b_corp, usda_organic, etc. renew annually)
+-- and soft-delete so retired signals stay attached to historical entity_signals rows.
+ALTER TABLE catalog.signals
+    ADD COLUMN has_expiry boolean NOT NULL DEFAULT false,
+    ADD COLUMN is_active  boolean NOT NULL DEFAULT true;
+
+-- Enhance catalog.availability: provenance flag + soft-delete.
+-- listing_source tracks who listed the item at this storefront.
+-- is_active = false delists from a storefront without losing the history of it
+-- ever being listed there (supports re-listing and audit trail).
+ALTER TABLE catalog.availability
+    ADD COLUMN listing_source text    NOT NULL DEFAULT 'storefront_listed'
+        CHECK (listing_source IN ('maker_listed', 'storefront_listed')),
+    ADD COLUMN listing_url    text,
+    ADD COLUMN is_active      boolean NOT NULL DEFAULT true;
+
+CREATE INDEX ON catalog.availability (storefront_id) WHERE is_active = true;
+
+-- Change item_id FK from ON DELETE CASCADE to ON DELETE RESTRICT.
+-- A maker delisting from their own storefront should delete their availability row only,
+-- not the catalog.items record. If the items record itself is deleted, Postgres should
+-- block it if any storefront still lists it — preventing silent removal of a consignment
+-- store's inventory when the original maker removes their product.
+ALTER TABLE catalog.availability
+    DROP CONSTRAINT availability_item_id_fkey;
+
+ALTER TABLE catalog.availability
+    ADD CONSTRAINT availability_item_id_fkey
+        FOREIGN KEY (item_id) REFERENCES catalog.items(id) ON DELETE RESTRICT;
+
+-- Enhance catalog.entity_signals: cert metadata for verified signals
+-- (cert_number and cert_expires_at are null for non-cert signals like identity_verified)
+ALTER TABLE catalog.entity_signals
+    ADD COLUMN cert_number     text,
+    ADD COLUMN cert_expires_at timestamptz,
+    ADD COLUMN verified_by     text;

--- a/services/cove-item/migrations/000008_seed_signals.down.sql
+++ b/services/cove-item/migrations/000008_seed_signals.down.sql
@@ -1,0 +1,11 @@
+DELETE FROM catalog.signals
+WHERE code IN (
+    'b_corp',
+    'usda_organic',
+    'fair_trade',
+    'one_pct_planet',
+    'colorado_proud',
+    'living_wage',
+    'identity_verified',
+    'business_registered'
+);

--- a/services/cove-item/migrations/000008_seed_signals.up.sql
+++ b/services/cove-item/migrations/000008_seed_signals.up.sql
@@ -1,0 +1,90 @@
+-- Signal taxonomy seed.
+-- verification_method values:
+--   'api_lookup'        — automated check against a public API (e.g. USDA NOP)
+--   'directory_crossref'— manual or scraped lookup against a public member directory
+--   'manual_review'     — staff reviews submitted documents / attestation
+--   'kyc'               — automated identity verification via Stripe Identity or Persona
+--
+-- weight reflects acquisition cost / credibility signal to buyers (1 = baseline, 3 = highest).
+-- has_expiry = true means the signal must be re-verified on renewal; the expiry job
+-- reads this flag to know which entity_signals rows to monitor.
+
+INSERT INTO catalog.signals (id, code, name, description, verification_method, weight, has_expiry) VALUES
+
+    -- Third-party certifications (highest weight — externally issued, hard to acquire)
+    (
+        gen_random_uuid(),
+        'b_corp',
+        'B Corp Certified',
+        'Certified by B Lab for meeting rigorous standards of social and environmental performance, accountability, and transparency. Requires comprehensive assessment and renews every three years.',
+        'directory_crossref',
+        3,
+        true
+    ),
+    (
+        gen_random_uuid(),
+        'usda_organic',
+        'USDA Organic',
+        'Certified organic by the USDA National Organic Program. Products meet strict federal standards for organic production and handling. Annual renewal required.',
+        'api_lookup',
+        3,
+        true
+    ),
+    (
+        gen_random_uuid(),
+        'fair_trade',
+        'Fair Trade Certified',
+        'Certified by Fair Trade USA. Workers receive fair wages, work in safe conditions, and farmers receive a price premium invested in their communities. Annual renewal required.',
+        'directory_crossref',
+        2,
+        true
+    ),
+    (
+        gen_random_uuid(),
+        'one_pct_planet',
+        '1% for the Planet',
+        'Member of 1% for the Planet, committing at least 1% of annual sales to vetted environmental nonprofit partners. Annual membership renewal required.',
+        'directory_crossref',
+        2,
+        true
+    ),
+    (
+        gen_random_uuid(),
+        'colorado_proud',
+        'Colorado Proud',
+        'Recognized by the Colorado Department of Agriculture as a Colorado-grown or Colorado-made product. Ongoing program membership verified against the CO Dept of Agriculture directory.',
+        'directory_crossref',
+        1,
+        false
+    ),
+
+    -- Staff-reviewed signals
+    (
+        gen_random_uuid(),
+        'living_wage',
+        'Living Wage Employer',
+        'Pays all workers at or above the MIT Living Wage for their county. Verified through staff-reviewed attestation and payroll documentation.',
+        'manual_review',
+        2,
+        false
+    ),
+
+    -- Identity and business verification (baseline trust signals)
+    (
+        gen_random_uuid(),
+        'identity_verified',
+        'Identity Verified',
+        'Maker identity confirmed via government-issued ID through automated KYC verification. Applies to individual makers operating without a registered business entity.',
+        'kyc',
+        1,
+        false
+    ),
+    (
+        gen_random_uuid(),
+        'business_registered',
+        'Registered Business',
+        'Verified as a registered business entity via D-U-N-S number or state business registry. Applies to LLCs, corporations, and registered sole proprietors.',
+        'manual_review',
+        1,
+        false
+    );

--- a/services/cove-item/migrations/000009_music_taxonomy_correction.down.sql
+++ b/services/cove-item/migrations/000009_music_taxonomy_correction.down.sql
@@ -1,0 +1,10 @@
+-- Restore format-specific leaves under music.recorded.
+-- Inserting them fires the categories_set_parent_non_leaf trigger (000005)
+-- which automatically sets music.recorded.is_leaf = false.
+
+DELETE FROM catalog.categories WHERE path = 'music.merch';
+
+INSERT INTO catalog.categories (id, name, path) VALUES
+    (gen_random_uuid(), 'Vinyl',    'music.recorded.vinyl'),
+    (gen_random_uuid(), 'CD',       'music.recorded.cd'),
+    (gen_random_uuid(), 'Cassette', 'music.recorded.cassette');

--- a/services/cove-item/migrations/000009_music_taxonomy_correction.up.sql
+++ b/services/cove-item/migrations/000009_music_taxonomy_correction.up.sql
@@ -1,0 +1,20 @@
+-- Remove format-specific leaves from music.recorded.
+--
+-- vinyl, cd, and cassette are product variants (packaging) of the same creative
+-- work, not structural category distinctions. Format is better expressed as an
+-- attribute on catalog.items (e.g. attributes->>'format' = 'cassette') where it
+-- is filterable without polluting the category tree.
+--
+-- After these three rows are deleted, the categories_recheck_parent_leaf trigger
+-- (000006) automatically sets music.recorded.is_leaf = true, making it the
+-- catch-all leaf for all recorded music.
+
+DELETE FROM catalog.categories WHERE path = 'music.recorded.vinyl';
+DELETE FROM catalog.categories WHERE path = 'music.recorded.cd';
+DELETE FROM catalog.categories WHERE path = 'music.recorded.cassette';
+
+-- Add music.merch as a leaf for artist merchandise (t-shirts, posters, accessories, etc.)
+-- Distinct from apparel.* which covers clothing brands — merch is tied to a music artist.
+-- Kept at 2 levels intentionally; sub-categories (music.merch.apparel, etc.) can be added later.
+INSERT INTO catalog.categories (id, name, path)
+VALUES (gen_random_uuid(), 'Merch', 'music.merch');

--- a/services/cove-item/migrations/000010_seed_directory.down.sql
+++ b/services/cove-item/migrations/000010_seed_directory.down.sql
@@ -1,0 +1,27 @@
+-- Remove in reverse FK dependency order.
+-- catalog.availability and catalog.media both have ON DELETE CASCADE from catalog.items,
+-- so deleting items cleans those up automatically.
+
+DELETE FROM catalog.items
+WHERE name IN (
+    'Colombia Familia Montano',
+    'Southern Weather Blend',
+    'Balloon Cargo Pant',
+    'Under The Weather'
+);
+
+DELETE FROM directory.storefronts
+WHERE slug IN (
+    'ritual-coffee-roasters-online',
+    'onyx-coffee-lab-online',
+    'iets-franz-online',
+    'homeshake-bandcamp'
+);
+
+DELETE FROM directory.makers
+WHERE slug IN (
+    'ritual-coffee-roasters',
+    'onyx-coffee-lab',
+    'iets-franz',
+    'homeshake'
+);

--- a/services/cove-item/migrations/000010_seed_directory.down.sql
+++ b/services/cove-item/migrations/000010_seed_directory.down.sql
@@ -1,6 +1,18 @@
 -- Remove in reverse FK dependency order.
--- catalog.availability and catalog.media both have ON DELETE CASCADE from catalog.items,
--- so deleting items cleans those up automatically.
+-- catalog.availability.item_id is ON DELETE RESTRICT (changed in 000007), so
+-- availability rows must be deleted before items. catalog.media.item_id is
+-- ON DELETE CASCADE so media is cleaned up automatically when items are deleted.
+
+DELETE FROM catalog.availability
+WHERE item_id IN (
+    SELECT id FROM catalog.items
+    WHERE name IN (
+        'Colombia Familia Montano',
+        'Southern Weather Blend',
+        'Balloon Cargo Pant',
+        'Under The Weather'
+    )
+);
 
 DELETE FROM catalog.items
 WHERE name IN (

--- a/services/cove-item/migrations/000010_seed_directory.up.sql
+++ b/services/cove-item/migrations/000010_seed_directory.up.sql
@@ -86,7 +86,7 @@ sf_onyx AS (
 
 sf_iets AS (
     INSERT INTO directory.storefronts (id, operated_by_maker_id, name, slug, type, website_url)
-    SELECT gen_random_uuid(), id, 'iets franz…', 'iets-franz-online', 'online', 'https://urbanoutfitters.com/iets-franz'
+    SELECT gen_random_uuid(), id, 'iets franz…', 'iets-franz-online', 'online', 'https://www.urbanoutfitters.com/brands/iets-frans'
     FROM maker_iets
     RETURNING id
 ),

--- a/services/cove-item/migrations/000010_seed_directory.up.sql
+++ b/services/cove-item/migrations/000010_seed_directory.up.sql
@@ -5,7 +5,7 @@
 --   Colombia Familia Montano  — Ritual Coffee Roasters  — food.coffee.whole_bean
 --   Southern Weather Blend    — Onyx Coffee Lab          — food.coffee.whole_bean
 --   Balloon Cargo Pant        — iets franz…              — apparel.unisex.bottoms
---   Under The Weather         — HOMESHAKE                — music.recorded.vinyl
+--   Under The Weather         — HOMESHAKE                — music.recorded
 --
 -- width/height on catalog.media are 0 — to be backfilled by the image pipeline.
 -- Dollar-quote tags: $d$ = description text, $j$ = jsonb literals.

--- a/services/cove-item/migrations/000010_seed_directory.up.sql
+++ b/services/cove-item/migrations/000010_seed_directory.up.sql
@@ -15,7 +15,7 @@ WITH
 -- ─── Makers ──────────────────────────────────────────────────────────────────
 
 maker_ritual AS (
-    INSERT INTO directory.makers (id, name, slug, description, tier, city, state, location)
+    INSERT INTO directory.makers (id, name, slug, description, tier, city, state, location, website_url)
     VALUES (
         gen_random_uuid(),
         'Ritual Coffee Roasters',
@@ -24,13 +24,14 @@ maker_ritual AS (
         'verified_business',
         'San Francisco',
         'CA',
-        ST_Point(-122.4213, 37.7582)::geography
+        ST_Point(-122.4213, 37.7582)::geography,
+        'https://ritualcoffee.com'
     )
     RETURNING id
 ),
 
 maker_onyx AS (
-    INSERT INTO directory.makers (id, name, slug, description, tier, city, state, location)
+    INSERT INTO directory.makers (id, name, slug, description, tier, city, state, location, website_url)
     VALUES (
         gen_random_uuid(),
         'Onyx Coffee Lab',
@@ -39,31 +40,34 @@ maker_onyx AS (
         'verified_business',
         'Springdale',
         'AR',
-        ST_Point(-94.1288, 36.1867)::geography
+        ST_Point(-94.1288, 36.1867)::geography,
+        'https://onyxcoffeelab.com'
     )
     RETURNING id
 ),
 
 maker_iets AS (
-    INSERT INTO directory.makers (id, name, slug, description, tier)
+    INSERT INTO directory.makers (id, name, slug, description, tier, website_url)
     VALUES (
         gen_random_uuid(),
         'iets franz…',
         'iets-franz',
         $d$Modern athleisure label crafting elevated sportswear basics, fresh silhouettes, and technical fabrications.$d$,
-        'verified_business'
+        'verified_business',
+        'https://www.urbanoutfitters.com/brands/iets-frans'
     )
     RETURNING id
 ),
 
 maker_homeshake AS (
-    INSERT INTO directory.makers (id, name, slug, description, tier)
+    INSERT INTO directory.makers (id, name, slug, description, tier, website_url)
     VALUES (
         gen_random_uuid(),
         'HOMESHAKE',
         'homeshake',
         $d$Peter Sagar, known as HOMESHAKE, is a Montreal-based musician making dreamy, lo-fi R&B.$d$,
-        'individual_lister'
+        'individual_lister',
+        'https://homeshake.bandcamp.com'
     )
     RETURNING id
 ),

--- a/services/cove-item/migrations/000010_seed_directory.up.sql
+++ b/services/cove-item/migrations/000010_seed_directory.up.sql
@@ -1,0 +1,251 @@
+-- Port Firestore products, product_details, and brands to Postgres.
+-- Source collections: products (4 docs), product_details (4 docs)
+--
+-- Items seeded:
+--   Colombia Familia Montano  — Ritual Coffee Roasters  — food.coffee.whole_bean
+--   Southern Weather Blend    — Onyx Coffee Lab          — food.coffee.whole_bean
+--   Balloon Cargo Pant        — iets franz…              — apparel.unisex.bottoms
+--   Under The Weather         — HOMESHAKE                — music.recorded.vinyl
+--
+-- width/height on catalog.media are 0 — to be backfilled by the image pipeline.
+-- Dollar-quote tags: $d$ = description text, $j$ = jsonb literals.
+
+WITH
+
+-- ─── Makers ──────────────────────────────────────────────────────────────────
+
+maker_ritual AS (
+    INSERT INTO directory.makers (id, name, slug, description, tier, city, state, location)
+    VALUES (
+        gen_random_uuid(),
+        'Ritual Coffee Roasters',
+        'ritual-coffee-roasters',
+        $d$A fully independent, woman-owned coffee sourcing and roasting company. Pioneer of specialty coffee on Valencia Street in San Francisco since 2005.$d$,
+        'verified_business',
+        'San Francisco',
+        'CA',
+        ST_Point(-122.4213, 37.7582)::geography
+    )
+    RETURNING id
+),
+
+maker_onyx AS (
+    INSERT INTO directory.makers (id, name, slug, description, tier, city, state, location)
+    VALUES (
+        gen_random_uuid(),
+        'Onyx Coffee Lab',
+        'onyx-coffee-lab',
+        $d$Specialty coffee roaster in Springdale, Arkansas, built on direct relationships with farms, organic practices, and ethical trading.$d$,
+        'verified_business',
+        'Springdale',
+        'AR',
+        ST_Point(-94.1288, 36.1867)::geography
+    )
+    RETURNING id
+),
+
+maker_iets AS (
+    INSERT INTO directory.makers (id, name, slug, description, tier)
+    VALUES (
+        gen_random_uuid(),
+        'iets franz…',
+        'iets-franz',
+        $d$Modern athleisure label crafting elevated sportswear basics, fresh silhouettes, and technical fabrications.$d$,
+        'verified_business'
+    )
+    RETURNING id
+),
+
+maker_homeshake AS (
+    INSERT INTO directory.makers (id, name, slug, description, tier)
+    VALUES (
+        gen_random_uuid(),
+        'HOMESHAKE',
+        'homeshake',
+        $d$Peter Sagar, known as HOMESHAKE, is a Montreal-based musician making dreamy, lo-fi R&B.$d$,
+        'individual_lister'
+    )
+    RETURNING id
+),
+
+-- ─── Storefronts (one online storefront per maker) ───────────────────────────
+
+sf_ritual AS (
+    INSERT INTO directory.storefronts (id, operated_by_maker_id, name, slug, type, website_url)
+    SELECT gen_random_uuid(), id, 'Ritual Coffee Roasters', 'ritual-coffee-roasters-online', 'online', 'https://ritualcoffee.com'
+    FROM maker_ritual
+    RETURNING id
+),
+
+sf_onyx AS (
+    INSERT INTO directory.storefronts (id, operated_by_maker_id, name, slug, type, website_url)
+    SELECT gen_random_uuid(), id, 'Onyx Coffee Lab', 'onyx-coffee-lab-online', 'online', 'https://onyxcoffeelab.com'
+    FROM maker_onyx
+    RETURNING id
+),
+
+sf_iets AS (
+    INSERT INTO directory.storefronts (id, operated_by_maker_id, name, slug, type, website_url)
+    SELECT gen_random_uuid(), id, 'iets franz…', 'iets-franz-online', 'online', 'https://urbanoutfitters.com/iets-franz'
+    FROM maker_iets
+    RETURNING id
+),
+
+sf_homeshake AS (
+    INSERT INTO directory.storefronts (id, operated_by_maker_id, name, slug, type, website_url)
+    SELECT gen_random_uuid(), id, 'HOMESHAKE Bandcamp', 'homeshake-bandcamp', 'online', 'https://homeshake.bandcamp.com'
+    FROM maker_homeshake
+    RETURNING id
+),
+
+-- ─── Category lookups ────────────────────────────────────────────────────────
+
+cat_whole_bean AS (
+    SELECT id FROM catalog.categories WHERE path = 'food.coffee.whole_bean'
+),
+
+cat_bottoms AS (
+    SELECT id FROM catalog.categories WHERE path = 'apparel.unisex.bottoms'
+),
+
+-- music.recorded.vinyl/cd/cassette were removed in 000009 (format = attribute).
+-- music.recorded is now the leaf for all recorded music.
+cat_recorded AS (
+    SELECT id FROM catalog.categories WHERE path = 'music.recorded'
+),
+
+-- ─── Items ───────────────────────────────────────────────────────────────────
+
+item_familia AS (
+    INSERT INTO catalog.items (id, maker_id, category_id, name, description, price_cents, attributes, details)
+    SELECT
+        gen_random_uuid(),
+        maker_ritual.id,
+        cat_whole_bean.id,
+        'Colombia Familia Montano',
+        $d$Carefully roasted by Ritual Coffee Roasters. Grown by Familia Montano in the Huila Department of Colombia using a Fully Washed process. Tasting notes: bing cherries, sugarcane, milk chocolate, and citrus.$d$,
+        2300,
+        $j${"roastery": "Ritual Coffee Roasters", "process": "Fully Washed", "origin_country": "Colombia", "producer": "Familia Montano", "region": "Palermo, Huila"}$j$::jsonb,
+        $j${"about": "Both internationally renowned and a local favorite, Ritual Coffee is a fully independent, woman-owned coffee sourcing and roasting company. Pioneer of the specialty coffee movement on Valencia Street in San Francisco since 2005.", "origin": [{"title": "Country", "content": "Colombia"}, {"title": "Variety", "content": "Colombia, Castillo"}, {"title": "Producer", "content": "Familia Montano"}, {"title": "Region", "content": "Palermo, Huila"}, {"title": "Process", "content": "Fully Washed"}]}$j$::jsonb
+    FROM maker_ritual, cat_whole_bean
+    RETURNING id
+),
+
+item_southern AS (
+    INSERT INTO catalog.items (id, maker_id, category_id, name, description, price_cents, attributes, details)
+    SELECT
+        gen_random_uuid(),
+        maker_onyx.id,
+        cat_whole_bean.id,
+        'Southern Weather Blend',
+        $d$Blended and roasted by Onyx Coffee Lab. Features coffees from Colombia and Ethiopia with notes of milk chocolate, plum, candied walnuts, and juicy citrus acidity.$d$,
+        2300,
+        $j${"roastery": "Onyx Coffee Lab", "process": "Fully Washed", "origin_country": "Colombia, Ethiopia", "altitude_m": 1850}$j$::jsonb,
+        $j${"about": "Onyx Coffee Lab is built on direct relationships with farms. Set on the East side of Springdale, Arkansas, it is a passion project from owners Jon and Andrea, committed to organic practices and ethical trading.", "origin": [{"title": "Country", "content": "Colombia, Ethiopia"}, {"title": "Process", "content": "Fully Washed"}, {"title": "Altitude", "content": "1850m"}, {"title": "Producer", "content": "Various Small Holder Producers"}]}$j$::jsonb
+    FROM maker_onyx, cat_whole_bean
+    RETURNING id
+),
+
+item_pants AS (
+    INSERT INTO catalog.items (id, maker_id, category_id, name, description, price_cents, attributes, details)
+    SELECT
+        gen_random_uuid(),
+        maker_iets.id,
+        cat_bottoms.id,
+        'Balloon Cargo Pant',
+        $d$Light and easy Y2K tech pants in a baggy parachute fit. Slouchy at the low drawcord waist and loose through the leg with a gathered drawcord at the hem. 100% Cotton.$d$,
+        7500,
+        $j${"brand": "iets franz…", "material": "100% Cotton", "fit": "Baggy", "rise": "Low"}$j$::jsonb,
+        $j${"about": "Crafting modern athleisure pieces, iets franz… is the go-to for elevated sportswear basics, fresh silhouettes, and technical fabrications.", "specifications": [{"title": "Features", "content": ["Baggy parachute pants", "Low-rise waist"]}, {"title": "Content + Care", "content": ["100% Cotton", "Machine wash", "Imported"]}, {"title": "Size + Fit", "content": ["Rise: 11.5\"", "Inseam: 30\"", "Leg opening: 10\""]}]}$j$::jsonb
+    FROM maker_iets, cat_bottoms
+    RETURNING id
+),
+
+item_utw AS (
+    INSERT INTO catalog.items (id, maker_id, category_id, name, description, price_cents, attributes, details)
+    SELECT
+        gen_random_uuid(),
+        maker_homeshake.id,
+        cat_recorded.id,
+        'Under The Weather',
+        $d$HOMESHAKE fifth studio album, written in 2019 during a long period of introspection in Montreal. Includes high-quality download in MP3, FLAC, and more.$d$,
+        900,
+        $j${"artist": "HOMESHAKE", "album": "Under The Weather", "format": "cassette"}$j$::jsonb,
+        $j${"about": "Peter Sagar wrote the majority of Under the Weather in 2019, when he was going through a long, unrelenting period of sadness. The album captures that quiet and restraint.", "tracklist": [{"title": "Wake Up!", "durationSec": 22}, {"title": "Feel Better", "durationSec": 254}, {"title": "Vacuum", "durationSec": 182}]}$j$::jsonb
+    FROM maker_homeshake, cat_recorded
+    RETURNING id
+),
+
+-- ─── Availability ────────────────────────────────────────────────────────────
+
+avail_familia AS (
+    INSERT INTO catalog.availability (item_id, storefront_id, listing_source, listing_url, is_active)
+    SELECT item_familia.id, sf_ritual.id, 'maker_listed', 'https://ritualcoffee.com/coffee/colombia-familia-montano', true
+    FROM item_familia, sf_ritual
+    RETURNING item_id
+),
+
+avail_southern AS (
+    INSERT INTO catalog.availability (item_id, storefront_id, listing_source, listing_url, is_active)
+    SELECT item_southern.id, sf_onyx.id, 'maker_listed', 'https://onyxcoffeelab.com/products/southern-weather-blend', true
+    FROM item_southern, sf_onyx
+    RETURNING item_id
+),
+
+avail_pants AS (
+    INSERT INTO catalog.availability (item_id, storefront_id, listing_source, listing_url, is_active)
+    SELECT item_pants.id, sf_iets.id, 'maker_listed', 'https://www.urbanoutfitters.com/shop/iets-franz-balloon-cargo-pant', true
+    FROM item_pants, sf_iets
+    RETURNING item_id
+),
+
+avail_utw AS (
+    INSERT INTO catalog.availability (item_id, storefront_id, listing_source, listing_url, is_active)
+    SELECT item_utw.id, sf_homeshake.id, 'maker_listed', 'https://homeshake.bandcamp.com/album/under-the-weather', true
+    FROM item_utw, sf_homeshake
+    RETURNING item_id
+),
+
+-- ─── Media (primary images) ──────────────────────────────────────────────────
+-- Chained from avail_* to ensure availability rows exist first.
+-- media_key values are the image storage paths carried over from Firestore.
+
+media_familia AS (
+    INSERT INTO catalog.media (id, item_id, media_key, role, sort_order, width, height)
+    SELECT gen_random_uuid(), avail_familia.item_id,
+           'images/198bd677d60fe63e71f2364a5b2f8b7f9dc390ab1a835179d37cc2b24a6f5680.webp',
+           'primary', 0, 0, 0
+    FROM avail_familia
+    RETURNING id
+),
+
+media_southern AS (
+    INSERT INTO catalog.media (id, item_id, media_key, role, sort_order, width, height)
+    SELECT gen_random_uuid(), avail_southern.item_id,
+           'images/782551befe683f93faab8047495213e78a8d8f5f74a1cf57e727fb09beed34e3.webp',
+           'primary', 0, 0, 0
+    FROM avail_southern
+    RETURNING id
+),
+
+media_pants AS (
+    INSERT INTO catalog.media (id, item_id, media_key, role, sort_order, width, height)
+    SELECT gen_random_uuid(), avail_pants.item_id,
+           'images/c700ae97872641c582c4dfdfa3769a0645cbfe4db33203b7e584a8e822a0d6a0.webp',
+           'primary', 0, 0, 0
+    FROM avail_pants
+    RETURNING id
+),
+
+media_utw AS (
+    INSERT INTO catalog.media (id, item_id, media_key, role, sort_order, width, height)
+    SELECT gen_random_uuid(), avail_utw.item_id,
+           'images/4b57be3e93a3aadd9df795b69490ef787647c9158b2dfbfdebd2a94c45680924.webp',
+           'primary', 0, 0, 0
+    FROM avail_utw
+    RETURNING id
+)
+
+-- Reference all leaf CTEs to ensure the full chain executes.
+SELECT 'Seeded 4 makers, 4 storefronts, 4 items, 4 availability rows, 4 media rows' AS result
+FROM media_familia, media_southern, media_pants, media_utw;


### PR DESCRIPTION
## Issue

* danicajiao/cove#319

## Summary

Seeds the signal taxonomy and ports existing Firestore data to Postgres via four new golang-migrate migrations:

- **000007** — Schema enhancements to existing tables: slugs, location columns, `is_active` soft-delete flags on makers/storefronts/availability, `listing_source` + `listing_url` + `is_active` on `catalog.availability`, `website_url` on storefronts, cert tracking columns on `catalog.entity_signals`, and a FK correction on `catalog.availability.item_id` (`CASCADE` → `RESTRICT` to prevent silent deletion of items still listed at independent storefronts)
- **000008** — Seeds 8 signals into `catalog.signals`: `b_corp`, `usda_organic`, `fair_trade`, `one_pct_planet`, `colorado_proud`, `living_wage`, `identity_verified`, `business_registered`. Note: `community_verified` removed (ratings/reviews are a separate social layer); `duns_verified` replaced by `business_registered` + `identity_verified` to handle both businesses and individual makers
- **000009** — Music taxonomy correction: removes `music.recorded.vinyl`, `music.recorded.cd`, `music.recorded.cassette` as separate leaves (format is an item attribute, not a category), making `music.recorded` the catch-all leaf. Adds `music.merch` for artist merchandise
- **000010** — Ports 4 Firestore items to Postgres: 4 makers, 4 online storefronts with `website_url`, 4 items with JSONB attributes and details, 4 availability rows with `listing_url`, 4 media rows

## Test plan

- [x] `migrate up` from version 6 applies 000007–000010 without error
- [x] `SELECT COUNT(*) FROM catalog.signals` returns 8
- [x] `SELECT COUNT(*) FROM directory.makers` returns 4
- [x] `SELECT COUNT(*) FROM catalog.items` returns 4
- [x] `SELECT COUNT(*) FROM catalog.availability` returns 4
- [x] `music.recorded` is a leaf (`is_leaf = true`), `music.recorded.vinyl/cd/cassette` do not exist
- [x] `music.merch` exists and is a leaf
- [x] Each item joined to correct maker, category, and storefront with listing and website URLs present
- [x] `migrate down` from version 10 back to version 6 cleanly reverses all changes

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)
