### PR TITLE
Fix checkout-before-sed ordering in bump-overlay-tags

### DIFF
--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -289,14 +289,7 @@ jobs:
             ENV_LABEL="staging"
           fi
 
-          # Rewrite the tag on every `newTag: sha-...` line. Match any run of
-          # non-whitespace after `sha-` (not just hex) so first-deploy
-          # placeholders like `sha-placeholder` are replaced cleanly — a hex-only
-          # class would match zero chars before `placeholder` and corrupt it.
-          for f in $OVERLAYS; do
-            sed -i "s|newTag: sha-[^[:space:]]*|newTag: ${NEW_TAG}|g" "$f"
-          done
-
+          # Checkout the branch before running sed so the working tree is clean.
           # If the remote branch already exists (e.g. a CI re-run for the same
           # commit), fetch it and base our local branch on top so the push isn't
           # rejected. If it doesn't exist yet, create a fresh branch as normal.
@@ -306,6 +299,15 @@ jobs:
           else
             git checkout -b "${BRANCH}"
           fi
+
+          # Rewrite the tag on every `newTag: sha-...` line. Match any run of
+          # non-whitespace after `sha-` (not just hex) so first-deploy
+          # placeholders like `sha-placeholder` are replaced cleanly — a hex-only
+          # class would match zero chars before `placeholder` and corrupt it.
+          for f in $OVERLAYS; do
+            sed -i "s|newTag: sha-[^[:space:]]*|newTag: ${NEW_TAG}|g" "$f"
+          done
+
           git add $OVERLAYS
           # Skip the commit if the re-run produced no diff (tags already at this SHA).
           git diff --cached --quiet || git commit -m "Bump cove services to sha-${SHORT_SHA} (${ENV_LABEL})"


### PR DESCRIPTION
## Summary

Fixes a bad ordering introduced in #354. The previous fix fetched the remote branch and attempted `git checkout` *after* `sed` had already modified the overlay files — git refused with:

```
error: Your local changes to the following files would be overwritten by checkout:
    apps/cove/overlays/staging/kustomization.yaml
Please commit your changes or stash them before you switch branches.
```

The fix is trivial: move the fetch + `checkout -b` block *above* the `sed` loop so the working tree is clean at checkout time, then apply the tag rewrite on the correct branch.

## Test plan

- [x] Re-run a `ci-services` workflow for a commit that already has a `deploy/` branch on homelab — job completes green, no duplicate PR opened
- [x] Fresh run on a new commit — branch created, PR opened as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
