### PR TITLE
Bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/cd-appstore.yml
+++ b/.github/workflows/cd-appstore.yml
@@ -48,7 +48,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Import Code Signing Certificates
-        uses: apple-actions/import-codesign-certs@v6
+        uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_PASSWORD }}
@@ -78,7 +78,7 @@ jobs:
 
 
       - name: Update release with App Store submission info
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TESTFLIGHT_TAG: ${{ steps.version.outputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -124,7 +124,7 @@ jobs:
             }
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: release-logs

--- a/.github/workflows/cd-testflight.yml
+++ b/.github/workflows/cd-testflight.yml
@@ -38,7 +38,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Import Code Signing Certificates
-        uses: apple-actions/import-codesign-certs@v6
+        uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_PASSWORD }}
@@ -87,7 +87,7 @@ jobs:
           echo "✓ Tag v${VERSION}-${BUILD} is unique and ready to be created"
 
       - name: Create GitHub Release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           VERSION: ${{ steps.version-info.outputs.version }}
           BUILD: ${{ steps.version-info.outputs.build }}
@@ -110,7 +110,7 @@ jobs:
             });
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: build-logs

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: services/cove-api/go.mod
           cache-dependency-path: services/cove-api/go.sum
@@ -59,7 +59,7 @@ jobs:
       # Does not run on PRs — PRs only build the image to verify it compiles.
       - name: Authenticate to Google Cloud
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build and push image (main / manual)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: services/cove-api
           push: true
@@ -81,7 +81,7 @@ jobs:
       # service still compiles. The image is not tagged or stored.
       - name: Build image (PR)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: services/cove-api
           push: false
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: services/cove-image/go.mod
           cache-dependency-path: services/cove-image/go.sum
@@ -122,7 +122,7 @@ jobs:
       # Does not run on PRs — PRs only build the image to verify it compiles.
       - name: Authenticate to Google Cloud
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
@@ -135,7 +135,7 @@ jobs:
       # the build context; the service Dockerfile is selected via file:.
       - name: Build and push image (main / manual)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: services/cove-image/Dockerfile
@@ -147,7 +147,7 @@ jobs:
       # service still compiles. The image is not tagged or stored.
       - name: Build image (PR)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: services/cove-image/Dockerfile
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: services/cove-item/go.mod
           cache-dependency-path: services/cove-item/go.sum
@@ -186,7 +186,7 @@ jobs:
       # Does not run on PRs — PRs only build the image to verify it compiles.
       - name: Authenticate to Google Cloud
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
@@ -199,7 +199,7 @@ jobs:
       # the build context; the service Dockerfile is selected via file:.
       - name: Build and push image (main / manual)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: services/cove-item/Dockerfile
@@ -211,7 +211,7 @@ jobs:
       # service still compiles. The image is not tagged or stored.
       - name: Build image (PR)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: services/cove-item/Dockerfile
@@ -231,7 +231,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: packages/imgproxy/go.mod
           # No external deps → no go.sum, so dependency caching has nothing to key on.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,7 +24,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

Bumps all pinned GitHub Actions to their current major releases to resolve Node 20 deprecation warnings.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-go` | `v5` | `v6` |
| `actions/upload-artifact` | `v6` | `v7` |
| `actions/github-script` | `v7` | `v9` |
| `docker/build-push-action` | `v6` | `v7` |
| `google-github-actions/auth` | `v2` | `v3` |
| `apple-actions/import-codesign-certs` | `v6` | `v7` |

`ruby/setup-ruby@v1` and `anthropics/claude-code-action@v1` are floating major-version tags and require no change.

## Test plan

- [x] CI - Services passes green
- [x] CI - iOS passes green
- [x] No Node 20 deprecation warnings in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
