### PR TITLE
Fix ISO8601 fractional seconds decoding for favorited_at

### DIFF
--- a/apps/ios/Cove/Networking/CoveAPIClient.swift
+++ b/apps/ios/Cove/Networking/CoveAPIClient.swift
@@ -46,6 +46,7 @@ final class CoveAPIClient: @unchecked Sendable {
         let middleware = FirebaseAuthMiddleware()
         client = Client(
             serverURL: serverURL,
+            configuration: .init(dateTranscoder: FractionalSecondsDateTranscoder()),
             transport: transport,
             middlewares: [middleware]
         )
@@ -357,6 +358,28 @@ enum CoveAPIError: Error {
     /// The server returned a documented 2xx response whose body could not be interpreted.
     /// The associated string describes what was wrong (e.g. a URL field that failed to parse).
     case invalidResponseBody(String)
+}
+
+// MARK: - FractionalSecondsDateTranscoder
+
+/// ISO8601 date transcoder that handles fractional seconds (e.g. "2026-06-10T19:52:45.808675Z").
+/// The default swift-openapi-generator transcoder uses ISO8601DateFormatter without
+/// .withFractionalSeconds, which rejects microsecond-precision timestamps from the API.
+struct FractionalSecondsDateTranscoder: DateTranscoder {
+    func encode(_ date: Date) throws -> String {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fmt.string(from: date)
+    }
+
+    func decode(_ string: String) throws -> Date {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = fmt.date(from: string) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid ISO8601 date: \(string)"))
+        }
+        return date
+    }
 }
 
 // MARK: - LocalizedError


### PR DESCRIPTION
## Summary

The default swift-openapi-generator `DateTranscoder` uses `ISO8601DateFormatter` without `.withFractionalSeconds`, which rejects microsecond-precision timestamps returned by the API (e.g. `"2026-06-10T19:52:45.808675Z"`). This caused favorites to fail to decode after the `favorited_at` field was fixed to emit proper RFC3339 in cove-user.

Adds `FractionalSecondsDateTranscoder` and wires it into `CoveAPIClient` via `ClientConfiguration`.

## Test plan

- [x] Favorites tab loads without decode error
- [x] Hearts show correctly on Home tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
