### PR TITLE
Ignore machine-specific buildServer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,9 @@ ExportOptions.plist
 # Uncomment if you want to track Gemfile.lock
 # Gemfile.lock
 
+### Xcode Build Server ###
+buildServer.json
+
 ### Claude ###
 .claude/.dep-cleared-*
 .claude/settings.local.json

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -40,6 +40,26 @@ apps/ios/Cove/Supporting Files/GoogleService-Info.plist
 
 Select a simulator or connected device in Xcode and press **⌘R**.
 
+### 5. (Optional) Set up VS Code with Swift LSP
+
+If you use VS Code, install the [Swift extension](https://marketplace.visualstudio.com/items?itemName=sswg.swift-lang) and then configure `xcode-build-server` so that SourceKit-LSP can understand the Xcode project. Without this, go-to-definition, hover docs, and symbol search won't work.
+
+```bash
+brew install xcode-build-server
+cd apps/ios
+xcode-build-server config -scheme Cove -project Cove.xcodeproj
+```
+
+This generates `apps/ios/buildServer.json` (gitignored — run it once per machine). Then open the project in VS Code using the workspace file:
+
+```bash
+open /path/to/Development/cove.code-workspace
+```
+
+> If you don't have a `cove.code-workspace` file yet, create one in your `Development` folder. See [the workspace file format](https://code.visualstudio.com/docs/editor/workspaces) — add `cove` and `cove/apps/ios` as separate folders so the Swift extension finds `buildServer.json`.
+
+If LSP features stop working after a large refactor or a DerivedData wipe, rebuild in Xcode (⌘B) to refresh the index. Re-run `xcode-build-server config` only if you rename the Xcode scheme or move the project.
+
 ## Notes
 
 - **Bundle ID:** `com.danicajiao.cove`
@@ -60,4 +80,4 @@ Select a simulator or connected device in Xcode and press **⌘R**.
 
 ---
 
-**Last Updated**: May 2026
+**Last Updated**: June 2026


### PR DESCRIPTION
## Summary

- Adds `buildServer.json` to `.gitignore`
- Documents the VS Code + Swift LSP setup in `docs/QUICK_START.md`

`buildServer.json` is generated by [`xcode-build-server`](https://github.com/SolaWing/xcode-build-server), a tool that bridges Xcode projects with SourceKit-LSP — the language server that powers go-to-definition, hover documentation, and symbol search in editors like VS Code.

Without it, SourceKit-LSP has no way to understand an Xcode project's compile flags (include paths, SDK, active scheme, preprocessor macros, etc.), so features like Command+Click simply don't work. `xcode-build-server` solves this by acting as a BSP (Build Server Protocol) server that answers SourceKit-LSP's questions about how each file is compiled — reading the information directly from Xcode's build system.

The generated file is machine-specific: the `build_root` field contains an absolute path to the user's local DerivedData directory (e.g. `~/Library/Developer/Xcode/DerivedData/Cove-<hash>/`), so it must not be committed. Each developer runs `xcode-build-server config -scheme Cove -project Cove.xcodeproj` once from `apps/ios/` after cloning.

## Test plan

- [x] `buildServer.json` does not appear as an untracked file after running `xcode-build-server config`
- [x] VS Code Command+Click works on Swift symbols after following the updated QUICK_START steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
