### PR TITLE
Add interest-picker onboarding screen

### DIFF
--- a/apps/ios/.git-hooks/pre-commit
+++ b/apps/ios/.git-hooks/pre-commit
@@ -1,7 +1,9 @@
 #!/bin/sh
 if which swiftformat > /dev/null 2>&1; then
-  swiftformat .
-  git add -u apps/ios/
+  if git diff --cached --name-only | grep -q '\.swift$'; then
+    swiftformat .
+    git add -u apps/ios/
+  fi
 else
   echo "warning: SwiftFormat not installed — skipping. Install with: brew install swiftformat"
 fi

--- a/apps/ios/Cove/Components/BackButton.swift
+++ b/apps/ios/Cove/Components/BackButton.swift
@@ -9,10 +9,11 @@ import SwiftUI
 
 struct BackButton: View {
     @Environment(\.dismiss) private var dismiss
+    var action: (() -> Void)?
 
     var body: some View {
         Button {
-            dismiss()
+            if let action { action() } else { dismiss() }
         } label: {
             Circle()
                 .fill(Color.Colors.Fills.inverse)

--- a/apps/ios/Cove/Enums/AuthPath.swift
+++ b/apps/ios/Cove/Enums/AuthPath.swift
@@ -1,9 +1,0 @@
-//
-//  AuthPath.swift
-//  Cove
-//
-
-enum AuthPath: Hashable {
-    case login
-    case signup
-}

--- a/apps/ios/Cove/Models/AppState.swift
+++ b/apps/ios/Cove/Models/AppState.swift
@@ -24,6 +24,7 @@ enum AuthState {
     case loggedIn
     case loggedOut
     case needsUsernameOnboarding
+    case needsInterestOnboarding
 }
 
 enum AuthMethod: String {
@@ -265,10 +266,10 @@ class AppState: ObservableObject {
 
     private func handlePostSignIn(method: AuthMethod) async {
         do {
-            _ = try await CoveAPIClient.shared.me()
+            let profile = try await CoveAPIClient.shared.me()
             await MainActor.run {
                 self.authMethod = method
-                self.authState = .loggedIn
+                self.authState = profile.interests_onboarded ? .loggedIn : .needsInterestOnboarding
             }
         } catch CoveAPIError.unexpectedStatus(404) {
             await MainActor.run {

--- a/apps/ios/Cove/Models/AppState.swift
+++ b/apps/ios/Cove/Models/AppState.swift
@@ -12,11 +12,8 @@ import GoogleSignIn
 import SwiftUI
 
 enum Path: Hashable {
-    case welcome
     case login
     case signup
-    case main
-    case home
     case item(id: String)
 }
 
@@ -38,6 +35,33 @@ class AppState: ObservableObject {
     @Published var authState: AuthState = .loggedOut
     var authMethod: AuthMethod?
 
+    private var authListener: AuthStateDidChangeListenerHandle?
+
+    init() {
+        authListener = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            guard let self else { return }
+            guard let user else {
+                setAuthState(.loggedOut)
+                return
+            }
+            let providerId = user.providerData.first?.providerID ?? ""
+            let method = AuthMethod(rawValue: providerId) ?? .email
+            Task {
+                await self.handlePostSignIn(method: method)
+            }
+        }
+    }
+
+    deinit {
+        if let authListener { Auth.auth().removeStateDidChangeListener(authListener) }
+    }
+
+    func setAuthState(_ state: AuthState) {
+        withAnimation {
+            authState = state
+        }
+    }
+
     func emailSignUp(email: String, password: String, onFailure: @escaping (Error?) -> Void, onSuccess: @escaping () -> Void) {
         Auth.auth().createUser(withEmail: email, password: password) { _, error in
             if error != nil {
@@ -45,7 +69,7 @@ class AppState: ObservableObject {
             } else {
                 DispatchQueue.main.async {
                     self.authMethod = .email
-                    self.authState = .needsUsernameOnboarding
+                    self.setAuthState(.needsUsernameOnboarding)
                 }
                 onSuccess()
             }
@@ -269,17 +293,17 @@ class AppState: ObservableObject {
             let profile = try await CoveAPIClient.shared.me()
             await MainActor.run {
                 self.authMethod = method
-                self.authState = profile.interests_onboarded ? .loggedIn : .needsInterestOnboarding
+                self.setAuthState(profile.interests_onboarded ? .loggedIn : .needsInterestOnboarding)
             }
         } catch CoveAPIError.unexpectedStatus(404) {
             await MainActor.run {
                 self.authMethod = method
-                self.authState = .needsUsernameOnboarding
+                self.setAuthState(.needsUsernameOnboarding)
             }
         } catch {
             await MainActor.run {
                 self.authMethod = method
-                self.authState = .loggedIn
+                self.setAuthState(.loggedIn)
             }
         }
     }
@@ -299,7 +323,7 @@ class AppState: ObservableObject {
                 try Auth.auth().signOut()
                 LoginManager().logOut()
                 DispatchQueue.main.async {
-                    self.authState = .loggedOut
+                    self.setAuthState(.loggedOut)
                     self.authMethod = nil
                 }
             } catch let signOutError as NSError {
@@ -311,7 +335,7 @@ class AppState: ObservableObject {
                 try Auth.auth().signOut()
                 GIDSignIn.sharedInstance.signOut()
                 DispatchQueue.main.async {
-                    self.authState = .loggedOut
+                    self.setAuthState(.loggedOut)
                     self.authMethod = nil
                 }
             } catch let signOutError as NSError {
@@ -322,7 +346,7 @@ class AppState: ObservableObject {
             do {
                 try Auth.auth().signOut()
                 DispatchQueue.main.async {
-                    self.authState = .loggedOut
+                    self.setAuthState(.loggedOut)
                     self.authMethod = nil
                 }
             } catch let signOutError as NSError {

--- a/apps/ios/Cove/Models/DiscoveryItem.swift
+++ b/apps/ios/Cove/Models/DiscoveryItem.swift
@@ -101,10 +101,10 @@ extension DiscoveryItem {
         makerID = detail.maker.id
         itemDescription = detail.description
 
-        media = detail.media ?? []
+        media = detail.media
 
         // Build the primary_image variants from the first primary media item
-        let primaryMedia = (detail.media ?? []).first(where: { $0.role == .primary })
+        let primaryMedia = detail.media.first(where: { $0.role == .primary })
         if let primaryMediaItem = primaryMedia {
             primaryImage = .init(
                 width: primaryMediaItem.width,

--- a/apps/ios/Cove/Models/TabState.swift
+++ b/apps/ios/Cove/Models/TabState.swift
@@ -7,7 +7,15 @@
 
 import Foundation
 
+enum Tab {
+    case home
+    case browse
+    case bag
+    case favorites
+    case profile
+}
+
 class TabState: Identifiable, ObservableObject {
-    @Published var currentTab = "home"
-    @Published var previousTab = "home"
+    @Published var currentTab: Tab = .home
+    @Published var previousTab: Tab = .home
 }

--- a/apps/ios/Cove/Networking/APIEnvironment.swift
+++ b/apps/ios/Cove/Networking/APIEnvironment.swift
@@ -28,7 +28,7 @@ enum APIEnvironment {
     // MARK: - Base URL
 
     var baseURL: URL {
-        let raw: String = switch self {
+        let raw = switch self {
         case .staging: "https://staging-api.coveapp.dev"
         case .production: "https://api.coveapp.dev"
         }

--- a/apps/ios/Cove/Networking/APIEnvironment.swift
+++ b/apps/ios/Cove/Networking/APIEnvironment.swift
@@ -28,14 +28,12 @@ enum APIEnvironment {
     // MARK: - Base URL
 
     var baseURL: URL {
-        switch self {
-        case .staging:
-            // swiftlint:disable:next force_unwrapping
-            URL(string: "https://staging-api.coveapp.dev")!
-        case .production:
-            // swiftlint:disable:next force_unwrapping
-            URL(string: "https://api.coveapp.dev")!
+        let raw: String = switch self {
+        case .staging: "https://staging-api.coveapp.dev"
+        case .production: "https://api.coveapp.dev"
         }
+        guard let url = URL(string: raw) else { preconditionFailure("Invalid base URL") }
+        return url
     }
 
     // MARK: - Current environment

--- a/apps/ios/Cove/Networking/CoveAPIClient.swift
+++ b/apps/ios/Cove/Networking/CoveAPIClient.swift
@@ -230,6 +230,47 @@ final class CoveAPIClient: @unchecked Sendable {
         }
     }
 
+    // MARK: - Categories
+
+    /// Fetches the full category tree from `GET /categories`.
+    ///
+    /// Used by the interest-picker onboarding screen and the browse surface.
+    func categories() async throws -> [Components.Schemas.CategoryNode] {
+        let response = try await client.getCategories()
+        switch response {
+        case let .ok(okResult):
+            return try okResult.body.json.categories
+        case .unauthorized:
+            throw CoveAPIError.unexpectedStatus(401)
+        case let .undocumented(statusCode, _):
+            throw CoveAPIError.unexpectedStatus(statusCode)
+        }
+    }
+
+    // MARK: - Interests
+
+    /// Replaces the authenticated user's interest categories via `PUT /users/me/interests`.
+    ///
+    /// Passing an empty array clears all interests. Returns on 204.
+    ///
+    /// - Parameter categoryIds: UUID strings of the selected leaf categories.
+    func replaceInterests(categoryIds: [String]) async throws {
+        let body = Components.Schemas.ReplaceInterestsRequest(category_ids: categoryIds)
+        let response = try await client.replaceInterests(body: .json(body))
+        switch response {
+        case .noContent:
+            return
+        case .badRequest:
+            throw CoveAPIError.unexpectedStatus(400)
+        case .unauthorized:
+            throw CoveAPIError.unexpectedStatus(401)
+        case .notFound:
+            throw CoveAPIError.unexpectedStatus(404)
+        case let .undocumented(statusCode, _):
+            throw CoveAPIError.unexpectedStatus(statusCode)
+        }
+    }
+
     // MARK: - Favorites
 
     /// Lists the authenticated user's favorited items from `GET /users/me/favorites`.

--- a/apps/ios/Cove/Networking/Generated/openapi.yaml
+++ b/apps/ios/Cove/Networking/Generated/openapi.yaml
@@ -1018,7 +1018,7 @@ components:
           format: uri
 
     ItemDetail:
-      required: [id, name, category_id, maker, signals, storefronts, media]
+      required: [id, name, category_id, maker, media]
       properties:
         id:
           type: string
@@ -1043,12 +1043,12 @@ components:
         maker:
           $ref: "#/components/schemas/MakerSummary"
         signals:
-          type: array
+          type: [array, "null"]
           description: Trust signals from all three levels (item, maker, storefront).
           items:
             $ref: "#/components/schemas/Signal"
         storefronts:
-          type: array
+          type: [array, "null"]
           items:
             $ref: "#/components/schemas/StorefrontDetailSummary"
         media:
@@ -1073,7 +1073,7 @@ components:
           type: string
 
     MakerDetail:
-      required: [id, name, tier, trust_score, signals, storefronts]
+      required: [id, name, tier, trust_score]
       properties:
         id:
           type: string
@@ -1097,11 +1097,11 @@ components:
           type: string
           format: uri
         signals:
-          type: array
+          type: [array, "null"]
           items:
             $ref: "#/components/schemas/Signal"
         storefronts:
-          type: array
+          type: [array, "null"]
           items:
             $ref: "#/components/schemas/MakerStorefront"
 
@@ -1124,7 +1124,7 @@ components:
           $ref: "#/components/schemas/ImageVariants"
 
     StorefrontDetail:
-      required: [id, name, type, trust_score, signals, items]
+      required: [id, name, type, trust_score]
       properties:
         id:
           type: string
@@ -1153,11 +1153,11 @@ components:
         maker_name:
           type: string
         signals:
-          type: array
+          type: [array, "null"]
           items:
             $ref: "#/components/schemas/Signal"
         items:
-          type: array
+          type: [array, "null"]
           items:
             $ref: "#/components/schemas/StorefrontItem"
 

--- a/apps/ios/Cove/Networking/Generated/openapi.yaml
+++ b/apps/ios/Cove/Networking/Generated/openapi.yaml
@@ -1018,7 +1018,7 @@ components:
           format: uri
 
     ItemDetail:
-      required: [id, name, category_id, maker]
+      required: [id, name, category_id, maker, signals, storefronts, media]
       properties:
         id:
           type: string
@@ -1165,7 +1165,7 @@ components:
 
     UserProfile:
       type: object
-      required: [uid, username, created_at]
+      required: [uid, username, created_at, interests_onboarded]
       properties:
         uid:
           type: string
@@ -1177,6 +1177,9 @@ components:
         created_at:
           type: string
           format: date-time
+        interests_onboarded:
+          type: boolean
+          description: True once PUT /users/me/interests has been called at least once (even with an empty array). Used to gate the interest-picker onboarding screen.
 
     CreateUserRequest:
       type: object

--- a/apps/ios/Cove/Supporting Files/CoveApp.swift
+++ b/apps/ios/Cove/Supporting Files/CoveApp.swift
@@ -78,6 +78,8 @@ struct CoveApp: App {
                         .environmentObject(bag)
                 } else if appState.authState == .needsUsernameOnboarding {
                     UsernameOnboardingView(appState: appState)
+                } else if appState.authState == .needsInterestOnboarding {
+                    InterestOnboardingView(appState: appState)
                 } else {
                     NavigationStack(path: $authPath) {
                         ZStack {

--- a/apps/ios/Cove/Supporting Files/CoveApp.swift
+++ b/apps/ios/Cove/Supporting Files/CoveApp.swift
@@ -63,7 +63,7 @@ struct CoveApp: App {
     @StateObject var favoritesStore = FavoritesStore()
     @StateObject private var networkMonitor = NetworkMonitor()
 
-    @State private var authPath: [AuthPath] = []
+    @State private var authScreen: Path?
 
     init() {
         print("init run")
@@ -71,54 +71,68 @@ struct CoveApp: App {
 
     var body: some Scene {
         WindowGroup {
-            Group {
-                if appState.authState == .loggedIn {
-                    MainView()
-                        .environment(\.imageRepository, CoveAPIImageRepository())
-                        .environmentObject(bag)
-                } else if appState.authState == .needsUsernameOnboarding {
-                    UsernameOnboardingView(appState: appState)
-                } else if appState.authState == .needsInterestOnboarding {
-                    InterestOnboardingView(appState: appState)
-                } else {
-                    NavigationStack(path: $authPath) {
-                        ZStack {
-                            if networkMonitor.isConnected {
-                                WelcomeView(
-                                    onNavigateToLogin: { authPath.append(.login) },
-                                    onNavigateToSignup: { authPath.append(.signup) }
-                                )
-                                .transition(.opacity)
-                            } else {
-                                SplashView()
-                                    .transition(.opacity)
-                            }
-                        }
-                        .animation(.default, value: networkMonitor.isConnected)
-                        .navigationDestination(for: AuthPath.self) { path in
-                            switch path {
-                            case .login:
-                                LoginView(onNavigateToSignup: { authPath.append(.signup) })
-                            case .signup:
-                                SignupView(onNavigateToLogin: { authPath.append(.login) })
-                            }
-                        }
-                    }
+            rootView
+                .animation(.default, value: appState.authState)
+                .task {
+                    #if DEBUG
+                        await runGatewaySmokeTest()
+                    #endif
                 }
+                .onChange(of: appState.authState) { _, newState in
+                    if newState == .loggedOut { authScreen = nil }
+                }
+                .environmentObject(appState)
+                .environmentObject(favoritesStore)
+                .onOpenURL { url in
+                    GIDSignIn.sharedInstance.handle(url)
+                    ApplicationDelegate.shared.application(UIApplication.shared, open: url, options: [:])
+                }
+        }
+    }
+
+    private var rootView: some View {
+        ZStack {
+            switch appState.authState {
+            case .loggedIn:
+                MainView()
+                    .environment(\.imageRepository, CoveAPIImageRepository())
+                    .environmentObject(bag)
+                    .transition(.opacity)
+            case .needsUsernameOnboarding:
+                UsernameOnboardingView(appState: appState)
+                    .transition(.opacity)
+            case .needsInterestOnboarding:
+                InterestOnboardingView(appState: appState)
+                    .transition(.opacity)
+            case .loggedOut:
+                authFlowView
+                    .animation(.default, value: networkMonitor.isConnected)
+                    .animation(.default, value: authScreen)
+                    .transition(.opacity)
             }
-            .task {
-                #if DEBUG
-                    await runGatewaySmokeTest()
-                #endif
-            }
-            .onChange(of: appState.authState) { _, _ in
-                authPath = []
-            }
-            .environmentObject(appState)
-            .environmentObject(favoritesStore)
-            .onOpenURL { url in
-                GIDSignIn.sharedInstance.handle(url)
-                ApplicationDelegate.shared.application(UIApplication.shared, open: url, options: [:])
+        }
+    }
+
+    private var authFlowView: some View {
+        ZStack {
+            if !networkMonitor.isConnected {
+                SplashView()
+                    .transition(.opacity)
+            } else {
+                switch authScreen {
+                case .login:
+                    LoginView(onBack: { authScreen = nil }, onNavigateToSignup: { authScreen = .signup })
+                        .transition(.opacity)
+                case .signup:
+                    SignupView(onBack: { authScreen = nil }, onNavigateToLogin: { authScreen = .login })
+                        .transition(.opacity)
+                default:
+                    WelcomeView(
+                        onNavigateToLogin: { authScreen = .login },
+                        onNavigateToSignup: { authScreen = .signup }
+                    )
+                    .transition(.opacity)
+                }
             }
         }
     }

--- a/apps/ios/Cove/View Models/InterestOnboardingViewModel.swift
+++ b/apps/ios/Cove/View Models/InterestOnboardingViewModel.swift
@@ -3,12 +3,14 @@
 //  Cove
 //
 
-import Foundation
+import SwiftUI
 
 struct CategorySection: Identifiable {
     let id: String
     let name: String
     let leaves: [LeafCategory]
+    let selectedFill: Color
+    let selectedText: Color
 }
 
 struct LeafCategory: Identifiable {
@@ -81,22 +83,30 @@ class InterestOnboardingViewModel: ObservableObject {
         appState.authState = .loggedIn
     }
 
-    private func buildSections(from nodes: [Components.Schemas.CategoryNode]) -> [CategorySection] {
-        nodes.compactMap { root in
-            var leaves: [LeafCategory] = []
-            extractLeaves(from: root, into: &leaves)
-            return leaves.isEmpty ? nil : CategorySection(id: root.id, name: root.name, leaves: leaves)
-        }
-    }
+    // Cycles through brand colors so each section gets a distinct selected-chip color.
+    // Pairs: (fill, text) — text chosen for legibility on that fill.
+    private static let sectionPalette: [(fill: Color, text: Color)] = [
+        (Color.Colors.Brand.coral, Color.Colors.Text.inverse),
+        (Color.Colors.Brand.amber, Color.Colors.Text.primary),
+        (Color.Colors.Brand.sage, Color.Colors.Text.inverse),
+        (Color.Colors.Brand.blue, Color.Colors.Text.inverse),
+        (Color.Colors.Brand.violet, Color.Colors.Text.primary),
+        (Color.Colors.Brand.accent, Color.Colors.Text.primary)
+    ]
 
-    private func extractLeaves(from node: Components.Schemas.CategoryNode, into leaves: inout [LeafCategory]) {
-        let children = node.children ?? []
-        if children.isEmpty {
-            leaves.append(LeafCategory(id: node.id, name: node.name))
-        } else {
-            for child in children {
-                extractLeaves(from: child, into: &leaves)
-            }
+    private func buildSections(from nodes: [Components.Schemas.CategoryNode]) -> [CategorySection] {
+        var index = 0
+        return nodes.compactMap { root in
+            let chips = (root.children ?? [])
+                .filter { !($0.children ?? []).isEmpty }
+                .map { LeafCategory(id: $0.id, name: $0.name) }
+            guard !chips.isEmpty else { return nil }
+            let palette = Self.sectionPalette[index % Self.sectionPalette.count]
+            index += 1
+            return CategorySection(
+                id: root.id, name: root.name, leaves: chips,
+                selectedFill: palette.fill, selectedText: palette.text
+            )
         }
     }
 }

--- a/apps/ios/Cove/View Models/InterestOnboardingViewModel.swift
+++ b/apps/ios/Cove/View Models/InterestOnboardingViewModel.swift
@@ -1,0 +1,102 @@
+//
+//  InterestOnboardingViewModel.swift
+//  Cove
+//
+
+import Foundation
+
+struct CategorySection: Identifiable {
+    let id: String
+    let name: String
+    let leaves: [LeafCategory]
+}
+
+struct LeafCategory: Identifiable {
+    let id: String
+    let name: String
+}
+
+@MainActor
+class InterestOnboardingViewModel: ObservableObject {
+    @Published var sections: [CategorySection] = []
+    @Published var selectedIDs: Set<String> = []
+    @Published var isLoading: Bool = false
+    @Published var isSubmitting: Bool = false
+    @Published var serverError: String?
+
+    private let appState: AppState
+
+    init(appState: AppState) {
+        self.appState = appState
+    }
+
+    var canSubmit: Bool {
+        !selectedIDs.isEmpty && !isSubmitting
+    }
+
+    func fetchCategories() async {
+        isLoading = true
+        do {
+            let nodes = try await CoveAPIClient.shared.categories()
+            sections = buildSections(from: nodes)
+        } catch {
+            print("❌ fetchCategories failed: \(error)")
+        }
+        isLoading = false
+    }
+
+    func toggle(id: String) {
+        if selectedIDs.contains(id) {
+            selectedIDs.remove(id)
+        } else {
+            selectedIDs.insert(id)
+        }
+    }
+
+    func submit() async {
+        guard canSubmit else { return }
+        isSubmitting = true
+        serverError = nil
+        do {
+            try await CoveAPIClient.shared.replaceInterests(categoryIds: Array(selectedIDs))
+            complete()
+        } catch {
+            print("❌ replaceInterests failed: \(error)")
+            serverError = "Something went wrong. Please try again."
+            isSubmitting = false
+        }
+    }
+
+    func skip() async {
+        isSubmitting = true
+        do {
+            try await CoveAPIClient.shared.replaceInterests(categoryIds: [])
+        } catch {
+            print("❌ skip replaceInterests failed: \(error)")
+        }
+        appState.authState = .loggedIn
+    }
+
+    private func complete() {
+        appState.authState = .loggedIn
+    }
+
+    private func buildSections(from nodes: [Components.Schemas.CategoryNode]) -> [CategorySection] {
+        nodes.compactMap { root in
+            var leaves: [LeafCategory] = []
+            extractLeaves(from: root, into: &leaves)
+            return leaves.isEmpty ? nil : CategorySection(id: root.id, name: root.name, leaves: leaves)
+        }
+    }
+
+    private func extractLeaves(from node: Components.Schemas.CategoryNode, into leaves: inout [LeafCategory]) {
+        let children = node.children ?? []
+        if children.isEmpty {
+            leaves.append(LeafCategory(id: node.id, name: node.name))
+        } else {
+            for child in children {
+                extractLeaves(from: child, into: &leaves)
+            }
+        }
+    }
+}

--- a/apps/ios/Cove/View Models/InterestOnboardingViewModel.swift
+++ b/apps/ios/Cove/View Models/InterestOnboardingViewModel.swift
@@ -76,11 +76,11 @@ class InterestOnboardingViewModel: ObservableObject {
         } catch {
             print("❌ skip replaceInterests failed: \(error)")
         }
-        appState.authState = .loggedIn
+        appState.setAuthState(.loggedIn)
     }
 
     private func complete() {
-        appState.authState = .loggedIn
+        appState.setAuthState(.loggedIn)
     }
 
     // Cycles through brand colors so each section gets a distinct selected-chip color.

--- a/apps/ios/Cove/View Models/UsernameOnboardingViewModel.swift
+++ b/apps/ios/Cove/View Models/UsernameOnboardingViewModel.swift
@@ -43,7 +43,7 @@ class UsernameOnboardingViewModel: ObservableObject {
 
         do {
             _ = try await CoveAPIClient.shared.createMe(username: trimmed)
-            appState.authState = .loggedIn
+            appState.authState = .needsInterestOnboarding
         } catch CoveAPIError.unexpectedStatus(409) {
             serverError = "That username is already taken. Try another."
             isLoading = false

--- a/apps/ios/Cove/View Models/UsernameOnboardingViewModel.swift
+++ b/apps/ios/Cove/View Models/UsernameOnboardingViewModel.swift
@@ -43,7 +43,7 @@ class UsernameOnboardingViewModel: ObservableObject {
 
         do {
             _ = try await CoveAPIClient.shared.createMe(username: trimmed)
-            appState.authState = .needsInterestOnboarding
+            appState.setAuthState(.needsInterestOnboarding)
         } catch CoveAPIError.unexpectedStatus(409) {
             serverError = "That username is already taken. Try another."
             isLoading = false

--- a/apps/ios/Cove/Views/LoginView.swift
+++ b/apps/ios/Cove/Views/LoginView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct LoginView: View {
     @EnvironmentObject private var appState: AppState
 
+    var onBack: () -> Void
     var onNavigateToSignup: () -> Void
 
     @State private var presentAlert = false
@@ -146,7 +147,7 @@ struct LoginView: View {
             .padding(Spacing.xl)
             .background(Color.Colors.Backgrounds.primary)
             .overlay(alignment: .topLeading) {
-                BackButton()
+                BackButton(action: onBack)
                     .padding(Spacing.xl)
             }
             .toolbar(.hidden, for: .navigationBar)
@@ -167,7 +168,7 @@ struct LoginView: View {
 struct LoginView_Previews: PreviewProvider {
     static let appState = AppState()
     static var previews: some View {
-        LoginView(onNavigateToSignup: {})
+        LoginView(onBack: {}, onNavigateToSignup: {})
             .environmentObject(appState)
     }
 }

--- a/apps/ios/Cove/Views/MainView.swift
+++ b/apps/ios/Cove/Views/MainView.swift
@@ -11,79 +11,57 @@ struct MainView: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var bag: Bag
     @StateObject private var tabState = TabState()
-    // @State private var opacity: Double = 0
 
     var body: some View {
         TabView(selection: $tabState.currentTab) {
             TabNavigationStack {
                 HomeView()
             }
-            .onTapGesture {
-                tabState.currentTab = "home"
-            }
             .tabItem {
-                Label("Home", systemImage: tabState.currentTab == "home" ? "house.fill" : "house")
+                Label("Home", systemImage: tabState.currentTab == .home ? "house.fill" : "house")
                     .environment(\.symbolVariants, .none)
             }
-            .tag("home")
+            .tag(Tab.home)
 
             TabNavigationStack {
                 Text("Browse View")
             }
-            .onTapGesture {
-                tabState.currentTab = "browse"
-            }
             .tabItem {
-                Label("Browse", systemImage: tabState.currentTab == "browse" ? "magnifyingglass" : "magnifyingglass")
+                Label("Browse", systemImage: "magnifyingglass")
                     .environment(\.symbolVariants, .none)
             }
-            .tag("browse")
+            .tag(Tab.browse)
 
             TabNavigationStack {
                 BagView()
             }
-            .onTapGesture {
-                tabState.currentTab = "bag"
-            }
             .tabItem {
-                Label("Bag", systemImage: tabState.currentTab == "bag" ? "bag.fill" : "bag")
+                Label("Bag", systemImage: tabState.currentTab == .bag ? "bag.fill" : "bag")
                     .environment(\.symbolVariants, .none)
             }
             .badge(bag.totalItems)
-            .tag("bag")
+            .tag(Tab.bag)
 
             TabNavigationStack {
                 FavoritesView()
             }
-            .onTapGesture {
-                tabState.currentTab = "favorites"
-            }
             .tabItem {
-                Label("Favorites", systemImage: tabState.currentTab == "favorites" ? "heart.fill" : "heart")
+                Label("Favorites", systemImage: tabState.currentTab == .favorites ? "heart.fill" : "heart")
                     .environment(\.symbolVariants, .none)
             }
-            .tag("favorites")
+            .tag(Tab.favorites)
 
             TabNavigationStack {
                 ProfileView()
             }
-            .onTapGesture {
-                tabState.currentTab = "profile"
-            }
             .tabItem {
-                Label("Profile", systemImage: tabState.currentTab == "profile" ? "person.crop.circle.fill" : "person.crop.circle")
+                Label("Profile", systemImage: tabState.currentTab == .profile ? "person.crop.circle.fill" : "person.crop.circle")
                     .environment(\.symbolVariants, .none)
             }
-            .tag("profile")
+            .tag(Tab.profile)
         }
         .environmentObject(tabState)
-        // .opacity(opacity)
         .background(Color.Colors.Backgrounds.primary)
-        .onAppear {
-            // withAnimation(.easeIn(duration: 1)) {
-            //     opacity = 1
-            // }
-        }
     }
 }
 

--- a/apps/ios/Cove/Views/Onboarding/InterestOnboardingView.swift
+++ b/apps/ios/Cove/Views/Onboarding/InterestOnboardingView.swift
@@ -73,7 +73,12 @@ struct InterestOnboardingView: View {
                                 .font(.custom("Lato-Bold", size: 16))
                                 .foregroundStyle(Color.Colors.Text.primary)
 
-                            ChipGrid(leaves: section.leaves, selectedIDs: viewModel.selectedIDs) { id in
+                            ChipGrid(
+                                leaves: section.leaves,
+                                selectedIDs: viewModel.selectedIDs,
+                                selectedFill: section.selectedFill,
+                                selectedText: section.selectedText
+                            ) { id in
                                 viewModel.toggle(id: id)
                             }
                         }
@@ -130,13 +135,20 @@ struct InterestOnboardingView: View {
 private struct ChipGrid: View {
     let leaves: [LeafCategory]
     let selectedIDs: Set<String>
+    let selectedFill: Color
+    let selectedText: Color
     let onTap: (String) -> Void
 
     var body: some View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: 100), spacing: Spacing.sm)], spacing: Spacing.sm) {
             ForEach(leaves) { leaf in
-                CategoryChip(name: leaf.name, isSelected: selectedIDs.contains(leaf.id))
-                    .onTapGesture { onTap(leaf.id) }
+                CategoryChip(
+                    name: leaf.name,
+                    isSelected: selectedIDs.contains(leaf.id),
+                    selectedFill: selectedFill,
+                    selectedText: selectedText
+                )
+                .onTapGesture { onTap(leaf.id) }
             }
         }
     }
@@ -147,16 +159,18 @@ private struct ChipGrid: View {
 private struct CategoryChip: View {
     let name: String
     let isSelected: Bool
+    let selectedFill: Color
+    let selectedText: Color
 
     var body: some View {
         Text(name)
             .font(.custom("Lato-Regular", size: 14))
-            .foregroundStyle(isSelected ? Color.Colors.Text.inverse : Color.Colors.Text.primary)
+            .foregroundStyle(isSelected ? selectedText : Color.Colors.Text.primary)
             .lineLimit(1)
             .padding(.horizontal, Spacing.md)
             .padding(.vertical, Spacing.sm)
             .frame(maxWidth: .infinity)
-            .background(isSelected ? Color.Colors.Fills.primary : Color.Colors.Fills.quinary)
+            .background(isSelected ? selectedFill : Color.Colors.Fills.quinary)
             .clipShape(Capsule())
             .overlay {
                 if !isSelected {

--- a/apps/ios/Cove/Views/Onboarding/InterestOnboardingView.swift
+++ b/apps/ios/Cove/Views/Onboarding/InterestOnboardingView.swift
@@ -1,0 +1,172 @@
+//
+//  InterestOnboardingView.swift
+//  Cove
+//
+
+import SwiftUI
+
+struct InterestOnboardingView: View {
+    @StateObject private var viewModel: InterestOnboardingViewModel
+
+    init(appState: AppState) {
+        _viewModel = StateObject(wrappedValue: InterestOnboardingViewModel(appState: appState))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            headerSection
+            contentSection
+            bottomSection
+        }
+        .background(Color.Colors.Backgrounds.primary.ignoresSafeArea(.all))
+        .task { await viewModel.fetchCategories() }
+    }
+
+    private var headerSection: some View {
+        VStack(spacing: Spacing.xl) {
+            Text("Cove.")
+                .font(.custom("Gazpacho-Heavy", size: 40))
+                .foregroundStyle(Color.Colors.Text.primary)
+
+            SpectrumDivider()
+
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                Text("What are you into?")
+                    .font(.custom("Lato-Bold", size: 28))
+                    .foregroundStyle(Color.Colors.Text.primary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text("Pick categories that match your style. We'll use them to personalize your home feed.")
+                    .font(.custom("Lato-Regular", size: 14))
+                    .foregroundStyle(Color.Colors.Text.tertiary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.horizontal, Spacing.xl)
+        .padding(.top, Spacing.xl)
+        .padding(.bottom, Spacing.lg)
+    }
+
+    @ViewBuilder
+    private var contentSection: some View {
+        if viewModel.isLoading {
+            Spacer()
+            ProgressView()
+            Spacer()
+        } else if viewModel.sections.isEmpty {
+            Spacer()
+            Text("Couldn't load categories.")
+                .font(.custom("Lato-Regular", size: 14))
+                .foregroundStyle(Color.Colors.Text.tertiary)
+            Button("Try again") {
+                Task { await viewModel.fetchCategories() }
+            }
+            .font(.custom("Lato-Bold", size: 14))
+            .foregroundStyle(Color.Colors.Brand.accent)
+            Spacer()
+        } else {
+            ScrollView(showsIndicators: false) {
+                LazyVStack(alignment: .leading, spacing: Spacing.xl) {
+                    ForEach(viewModel.sections) { section in
+                        VStack(alignment: .leading, spacing: Spacing.sm) {
+                            Text(section.name)
+                                .font(.custom("Lato-Bold", size: 16))
+                                .foregroundStyle(Color.Colors.Text.primary)
+
+                            ChipGrid(leaves: section.leaves, selectedIDs: viewModel.selectedIDs) { id in
+                                viewModel.toggle(id: id)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, Spacing.xl)
+                .padding(.bottom, Spacing.md)
+            }
+        }
+    }
+
+    private var bottomSection: some View {
+        VStack(spacing: Spacing.md) {
+            if let error = viewModel.serverError {
+                Text(error)
+                    .font(.custom("Lato-Regular", size: 12))
+                    .foregroundStyle(Color.Colors.Support.Error.fg)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+
+            Button {
+                Task { await viewModel.submit() }
+            } label: {
+                if viewModel.isSubmitting {
+                    ProgressView().tint(.white)
+                } else {
+                    Text("Continue")
+                }
+            }
+            .buttonStyle(PrimaryButton())
+            .disabled(!viewModel.canSubmit)
+
+            Button {
+                Task { await viewModel.skip() }
+            } label: {
+                Text("Skip for now")
+                    .font(.custom("Lato-Regular", size: 14))
+                    .foregroundStyle(Color.Colors.Text.tertiary)
+            }
+
+            Text("Don't worry, you can change this later.")
+                .font(.custom("Lato-Regular", size: 12))
+                .foregroundStyle(Color.Colors.Text.quaternary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, Spacing.xl)
+        .padding(.top, Spacing.md)
+        .padding(.bottom, Spacing.xl)
+    }
+}
+
+// MARK: - ChipGrid
+
+private struct ChipGrid: View {
+    let leaves: [LeafCategory]
+    let selectedIDs: Set<String>
+    let onTap: (String) -> Void
+
+    var body: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 100), spacing: Spacing.sm)], spacing: Spacing.sm) {
+            ForEach(leaves) { leaf in
+                CategoryChip(name: leaf.name, isSelected: selectedIDs.contains(leaf.id))
+                    .onTapGesture { onTap(leaf.id) }
+            }
+        }
+    }
+}
+
+// MARK: - CategoryChip
+
+private struct CategoryChip: View {
+    let name: String
+    let isSelected: Bool
+
+    var body: some View {
+        Text(name)
+            .font(.custom("Lato-Regular", size: 14))
+            .foregroundStyle(isSelected ? Color.Colors.Text.inverse : Color.Colors.Text.primary)
+            .lineLimit(1)
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.sm)
+            .frame(maxWidth: .infinity)
+            .background(isSelected ? Color.Colors.Fills.primary : Color.Colors.Fills.quinary)
+            .clipShape(Capsule())
+            .overlay {
+                if !isSelected {
+                    Capsule().stroke(Color.Colors.Strokes.primary.opacity(0.3), lineWidth: 1)
+                }
+            }
+            .animation(.easeInOut(duration: 0.15), value: isSelected)
+    }
+}
+
+#Preview {
+    InterestOnboardingView(appState: AppState())
+}

--- a/apps/ios/Cove/Views/SignupView.swift
+++ b/apps/ios/Cove/Views/SignupView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct SignupView: View {
     @EnvironmentObject private var appState: AppState
 
+    var onBack: () -> Void
     var onNavigateToLogin: () -> Void
 
     @State private var presentAlert = false
@@ -148,7 +149,7 @@ struct SignupView: View {
             .padding(Spacing.xl)
             .background(Color.Colors.Backgrounds.primary)
             .overlay(alignment: .topLeading) {
-                BackButton()
+                BackButton(action: onBack)
                     .padding(Spacing.xl)
             }
             .toolbar(.hidden, for: .navigationBar)
@@ -169,7 +170,7 @@ struct SignupView: View {
 struct SignupView_Previews: PreviewProvider {
     static let appState = AppState()
     static var previews: some View {
-        SignupView(onNavigateToLogin: {})
+        SignupView(onBack: {}, onNavigateToLogin: {})
             .environmentObject(appState)
     }
 }

--- a/apps/ios/Cove/Views/TabNavigationStack.swift
+++ b/apps/ios/Cove/Views/TabNavigationStack.swift
@@ -24,9 +24,7 @@ struct TabNavigationStack<Content: View>: View {
                         ItemDetailView(itemId: id)
                             .environmentObject(bag)
                     default:
-                        #if DEBUG
-                            let _ = print("⚠️ Unhandled navigation path in TabNavigationStack: \(path)")
-                        #endif
+                        let _ = assertionFailure("Unhandled navigation path: \(path)")
                         EmptyView()
                     }
                 }

--- a/services/cove-api/api/openapi.yaml
+++ b/services/cove-api/api/openapi.yaml
@@ -1018,7 +1018,7 @@ components:
           format: uri
 
     ItemDetail:
-      required: [id, name, category_id, maker, signals, storefronts, media]
+      required: [id, name, category_id, maker, media]
       properties:
         id:
           type: string
@@ -1043,12 +1043,12 @@ components:
         maker:
           $ref: "#/components/schemas/MakerSummary"
         signals:
-          type: array
+          type: [array, "null"]
           description: Trust signals from all three levels (item, maker, storefront).
           items:
             $ref: "#/components/schemas/Signal"
         storefronts:
-          type: array
+          type: [array, "null"]
           items:
             $ref: "#/components/schemas/StorefrontDetailSummary"
         media:
@@ -1073,7 +1073,7 @@ components:
           type: string
 
     MakerDetail:
-      required: [id, name, tier, trust_score, signals, storefronts]
+      required: [id, name, tier, trust_score]
       properties:
         id:
           type: string
@@ -1097,11 +1097,11 @@ components:
           type: string
           format: uri
         signals:
-          type: array
+          type: [array, "null"]
           items:
             $ref: "#/components/schemas/Signal"
         storefronts:
-          type: array
+          type: [array, "null"]
           items:
             $ref: "#/components/schemas/MakerStorefront"
 
@@ -1124,7 +1124,7 @@ components:
           $ref: "#/components/schemas/ImageVariants"
 
     StorefrontDetail:
-      required: [id, name, type, trust_score, signals, items]
+      required: [id, name, type, trust_score]
       properties:
         id:
           type: string
@@ -1153,11 +1153,11 @@ components:
         maker_name:
           type: string
         signals:
-          type: array
+          type: [array, "null"]
           items:
             $ref: "#/components/schemas/Signal"
         items:
-          type: array
+          type: [array, "null"]
           items:
             $ref: "#/components/schemas/StorefrontItem"
 

--- a/services/cove-api/api/openapi.yaml
+++ b/services/cove-api/api/openapi.yaml
@@ -1165,7 +1165,7 @@ components:
 
     UserProfile:
       type: object
-      required: [uid, username, created_at]
+      required: [uid, username, created_at, interests_onboarded]
       properties:
         uid:
           type: string
@@ -1177,6 +1177,9 @@ components:
         created_at:
           type: string
           format: date-time
+        interests_onboarded:
+          type: boolean
+          description: True once PUT /users/me/interests has been called at least once (even with an empty array). Used to gate the interest-picker onboarding screen.
 
     CreateUserRequest:
       type: object

--- a/services/cove-user/internal/handler/mock_store_test.go
+++ b/services/cove-user/internal/handler/mock_store_test.go
@@ -90,32 +90,42 @@ func (r *intRow) Scan(dest ...any) error {
 
 // ── profileRow ────────────────────────────────────────────────────────────────
 
-// profileRow scans auth_uid, username, created_at for GetMeHandler /
-// CreateUserHandler. Email was removed from the schema in migration 000002.
+// profileRow scans the user profile columns.
+// GetMeHandler scans 4 columns (uid, username, created_at, interests_onboarded via EXISTS).
+// CreateUserHandler scans 3 (uid, username, created_at — new users always have no flags).
 type profileRow struct {
-	uid, username string
-	createdAt     time.Time
+	uid, username      string
+	createdAt          time.Time
+	interestsOnboarded bool
 }
 
 func (r *profileRow) Scan(dest ...any) error {
-	if len(dest) != 3 {
-		return fmt.Errorf("profileRow: expected 3 dest, got %d", len(dest))
+	if len(dest) != 3 && len(dest) != 4 {
+		return fmt.Errorf("profileRow: expected 3 or 4 dest, got %d", len(dest))
 	}
-	strs := []*string{nil, nil}
 	for i, d := range dest[:2] {
 		p, ok := d.(*string)
 		if !ok {
 			return fmt.Errorf("profileRow: dest[%d] is %T, want *string", i, d)
 		}
-		strs[i] = p
+		if i == 0 {
+			*p = r.uid
+		} else {
+			*p = r.username
+		}
 	}
-	p, ok := dest[2].(*time.Time)
+	pt, ok := dest[2].(*time.Time)
 	if !ok {
 		return fmt.Errorf("profileRow: dest[2] is %T, want *time.Time", dest[2])
 	}
-	*strs[0] = r.uid
-	*strs[1] = r.username
-	*p = r.createdAt
+	*pt = r.createdAt
+	if len(dest) == 4 {
+		pb, ok := dest[3].(*bool)
+		if !ok {
+			return fmt.Errorf("profileRow: dest[3] is %T, want *bool", dest[3])
+		}
+		*pb = r.interestsOnboarded
+	}
 	return nil
 }
 

--- a/services/cove-user/internal/handler/users.go
+++ b/services/cove-user/internal/handler/users.go
@@ -14,10 +14,16 @@ import (
 
 // ── User profile ──────────────────────────────────────────────────────────────
 
+// User flag constants — presence of a row in profile.user_flags with this value means the flag is set.
+const (
+	flagInterestsOnboarded = "interests_onboarded"
+)
+
 type userProfile struct {
-	UID       string    `json:"uid"`       // auth_uid — Firebase UID exposed as "uid" for API compatibility
-	Username  string    `json:"username"`
-	CreatedAt time.Time `json:"created_at"`
+	UID                string    `json:"uid"`                 // auth_uid — Firebase UID exposed as "uid" for API compatibility
+	Username           string    `json:"username"`
+	CreatedAt          time.Time `json:"created_at"`
+	InterestsOnboarded bool      `json:"interests_onboarded"` // true once PUT /users/me/interests has been called
 }
 
 // GetMeHandler handles GET /users/me.
@@ -26,12 +32,13 @@ func (d *Deps) GetMeHandler(w http.ResponseWriter, r *http.Request) {
 	authUID := r.Header.Get("X-Cove-Uid")
 
 	const q = `
-SELECT auth_uid, username, created_at
-FROM profile.users
-WHERE auth_uid = $1`
+SELECT u.auth_uid, u.username, u.created_at,
+       EXISTS(SELECT 1 FROM profile.user_flags f WHERE f.user_id = u.id AND f.flag = 'interests_onboarded')
+FROM profile.users u
+WHERE u.auth_uid = $1`
 
 	var u userProfile
-	err := d.DB.QueryRow(r.Context(), q, authUID).Scan(&u.UID, &u.Username, &u.CreatedAt)
+	err := d.DB.QueryRow(r.Context(), q, authUID).Scan(&u.UID, &u.Username, &u.CreatedAt, &u.InterestsOnboarded)
 	if err != nil {
 		if isNotFound(err) {
 			writeError(w, http.StatusNotFound, "user profile not found")
@@ -67,6 +74,7 @@ RETURNING auth_uid, username, created_at`
 	var u userProfile
 	err := d.DB.QueryRow(r.Context(), q, authUID, strings.TrimSpace(req.Username)).
 		Scan(&u.UID, &u.Username, &u.CreatedAt)
+	// New users have no flags yet — interests_onboarded is always false on creation.
 	if err != nil {
 		if isDuplicate(err) {
 			// Distinguish which unique constraint fired:
@@ -531,6 +539,14 @@ func (d *Deps) ReplaceInterestsHandler(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "interests replace failed")
 			return
 		}
+	}
+
+	if _, err := tx.Exec(r.Context(),
+		`INSERT INTO profile.user_flags (user_id, flag) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+		userID, flagInterestsOnboarded); err != nil {
+		log.Printf("ERROR ReplaceInterestsHandler flag user_id=%s: %v", userID, err)
+		writeError(w, http.StatusInternalServerError, "interests replace failed")
+		return
 	}
 
 	if err := tx.Commit(r.Context()); err != nil {

--- a/services/cove-user/internal/handler/users_test.go
+++ b/services/cove-user/internal/handler/users_test.go
@@ -54,9 +54,10 @@ func TestGetMeHandler_UserFound(t *testing.T) {
 		DB: &mockStore{
 			queryRowFn: func(ctx context.Context, sql string, args ...any) Row {
 				return &profileRow{
-					uid:       "uid-123",
-					username:  "testuser",
-					createdAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+					uid:                "uid-123",
+					username:           "testuser",
+					createdAt:          time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+					interestsOnboarded: false,
 				}
 			},
 		},
@@ -107,7 +108,7 @@ func TestCreateUserHandler_Success(t *testing.T) {
 	deps := &Deps{
 		DB: &mockStore{
 			queryRowFn: func(ctx context.Context, sql string, args ...any) Row {
-				return &profileRow{uid: "uid-123", username: "johndoe", createdAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+				return &profileRow{uid: "uid-123", username: "johndoe", createdAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), interestsOnboarded: false}
 			},
 		},
 		CommitSHA: "test",
@@ -363,8 +364,8 @@ func TestReplaceInterestsHandler_ValidRequest(t *testing.T) {
 	if rr.Code != http.StatusNoContent {
 		t.Errorf("expected 204, got %d", rr.Code)
 	}
-	// 1 DELETE + 2 INSERTs = 3 Exec calls.
-	if execCount != 3 {
-		t.Errorf("expected 3 Exec calls (1 DELETE + 2 INSERT), got %d", execCount)
+	// 1 DELETE + 2 INSERTs + 1 UPDATE (interests_onboarded) = 4 Exec calls.
+	if execCount != 4 {
+		t.Errorf("expected 4 Exec calls (1 DELETE + 2 INSERT + 1 UPDATE), got %d", execCount)
 	}
 }

--- a/services/cove-user/migrations/000002_interests_onboarded.down.sql
+++ b/services/cove-user/migrations/000002_interests_onboarded.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS profile.user_flags;

--- a/services/cove-user/migrations/000002_interests_onboarded.up.sql
+++ b/services/cove-user/migrations/000002_interests_onboarded.up.sql
@@ -1,0 +1,15 @@
+-- Generic per-user flags table. Each row records that a named flag was set for
+-- a user, along with when. Presence of a row is the flag — no value column needed.
+-- Adding new flags requires no schema changes, only a new string constant in the service.
+--
+-- Current flags:
+--   interests_onboarded — set when PUT /users/me/interests is called (even with an empty array)
+
+CREATE TABLE profile.user_flags (
+    user_id    uuid        NOT NULL REFERENCES profile.users(id) ON DELETE CASCADE,
+    flag       text        NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, flag)
+);
+
+GRANT SELECT, INSERT, DELETE ON profile.user_flags TO cove_user;


### PR DESCRIPTION
## Issue

* danicajiao/cove#325

## Summary

**Interest picker onboarding**
- Add `InterestOnboardingView` and `InterestOnboardingViewModel`: full-screen chip picker with section headers, multi-select, Continue/Skip buttons, and "Don't worry, you can change this later." note
- Per-section brand colors assigned to chips (coral, amber, sage, blue, violet, accent cycling across sections)
- Filter to non-leaf categories only — chips show intermediate nodes that have children, not deepest leaves
- Add `profile.user_flags` migration (000002): generic per-user flag table; presence of a row = flag set
- `GET /users/me` returns `interests_onboarded` via EXISTS subquery; new `needsInterestOnboarding` AuthState gates routing
- Skip calls `PUT /users/me/interests` with `[]` — marks the flag without selecting categories so the screen never re-appears cross-device
- Sync `openapi.yaml` with `interests_onboarded` boolean on `UserProfile`; add `categories()` and `replaceInterests(categoryIds:)` to `CoveAPIClient`

**Auth flow + navigation cleanup**
- Replace `NavigationStack` auth flow with `ZStack` + `.transition(.opacity)` for smooth opacity animations between all onboarding and auth views
- Add `Tab` enum replacing stringly-typed `currentTab: String` in `TabState`
- Add Firebase `addStateDidChangeListener` in `AppState.init()` for session restore on launch
- Fix `BackButton` on `LoginView`/`SignupView` — added explicit `onBack` callback since `@Environment(\.dismiss)` only works inside a `NavigationStack`
- Delete `AuthPath.swift`; clean dead `.welcome`/`.main`/`.home` cases from `Path` enum

**OpenAPI spec**
- Mark `signals` and `storefronts` as `type: [array, "null"]` and remove from `required` in `ItemDetail`, `MakerDetail`, and `StorefrontDetail` — cove-item returns `null` for these when unpopulated, causing iOS decoding errors

**Tooling**
- Wire `core.hooksPath` to `apps/ios/.git-hooks/`; update pre-commit hook to skip swiftformat when no Swift files are staged

## Test plan

- [x] Sign up with a new account → username screen → interest picker appears
- [x] Interest picker chips show per-section brand colors when selected
- [x] Select categories and tap Continue → lands on home tab; re-login skips picker
- [x] Tap "Skip for now" → lands on home tab; re-login skips picker
- [x] Sign in with an existing account that already has `interests_onboarded` flag → picker not shown
- [x] App relaunch while logged in → session restored, no re-login required
- [x] Transitions between Welcome → Login/Signup → Onboarding screens are opacity fades (no slide)
- [x] Back buttons on Login and Signup return to Welcome screen
- [x] Open an item detail view → no decoding error for `signals`/`storefronts`
- [x] `GET /categories` failure → empty-state with "Try again" button
- [x] `swiftformat` and `swiftlint --strict` pass from `apps/ios/`

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
