### PR TITLE
Docs: close residual Phase 3 stale-reference gaps

### DIFF
--- a/docs/IOS_APP_ARCHITECTURE.md
+++ b/docs/IOS_APP_ARCHITECTURE.md
@@ -52,18 +52,31 @@ apps/ios/Cove/
 
 ### Auth-Driven Routing
 
-`CoveApp` is the root of the app. It reads `AppState.authState` to decide which UI to show:
+`CoveApp` is the root of the app. It switches on `AppState.authState` (four cases) to decide which UI to show:
 
 ```mermaid
 flowchart TD
-    CoveApp["CoveApp (root)<br/>reads AppState.authState"]
-    CoveApp -->|".loggedIn"| Main["MainView<br/>(tab bar)"]
-    CoveApp -->|".loggedOut"| Auth["NavigationStack<br/>(auth flow)"]
+    CoveApp["CoveApp (root)<br/>switches on AppState.authState"]
+    CoveApp -->|".loggedOut"| Auth["auth flow"]
     Auth -->|"network available"| Welcome["WelcomeView"]
     Auth -->|"no network"| Splash["SplashView"]
+    CoveApp -->|".needsUsernameOnboarding"| UN["UsernameOnboardingView"]
+    CoveApp -->|".needsInterestOnboarding"| IO["InterestOnboardingView"]
+    CoveApp -->|".loggedIn"| Main["MainView (tab bar)"]
+    UN -.->|"username set"| IO
+    IO -.->|"interests_onboarded"| Main
 ```
 
-`AppState` holds `@Published var authState: AuthState`. When a user successfully signs in, `authState` flips to `.loggedIn`, which triggers `CoveApp` to rebuild and show `MainView`. Auth navigation is owned locally by `CoveApp` via `@State private var authPath: [AuthPath]`, which is reset to `[]` via `.onChange(of: appState.authState)` on logout.
+`AppState` holds `@Published var authState: AuthState` (`.loggedOut`, `.needsUsernameOnboarding`, `.needsInterestOnboarding`, `.loggedIn`). Auth navigation is owned locally by `CoveApp` via `@State private var authPath: [AuthPath]`, which is reset to `[]` via `.onChange(of: appState.authState)` on logout.
+
+### Post-sign-in onboarding
+
+After Firebase sign-in, `AppState` gates entry into the app on two `cove-user`-backed checks before reaching `.loggedIn`:
+
+1. **Username** — if the signed-in user has no username, `authState` becomes `.needsUsernameOnboarding` and `UsernameOnboardingView` collects one (persisted via `cove-user`, `POST /users/me`).
+2. **Interests** — `AppState` then loads the profile and reads the `interests_onboarded` flag. If `false`, `authState` becomes `.needsInterestOnboarding` and `InterestOnboardingView` fetches the category tree (`GET /categories`), lets the user pick leaf categories, and saves them via `PUT /users/me/interests` (which sets `interests_onboarded`). If already onboarded, it goes straight to `.loggedIn`.
+
+Once both checks pass, `authState` flips to `.loggedIn` and `MainView` is shown.
 
 ### Supported Auth Methods
 
@@ -157,7 +170,7 @@ Injected at the root (`CoveApp`) via `.environmentObject` and available througho
 - `favoriteIds: Set<String>` — the set of favorited item IDs for the current user
 - `isTogglingFavorite: Bool` — prevents concurrent toggle operations
 - Listens to `Auth.auth().addStateDidChangeListener` to load favorites on sign-in and clear them on sign-out
-- `toggle(_:categoryId:)` — optimistically updates `favoriteIds` locally, then syncs to Firestore
+- `toggle(_:categoryId:)` — optimistically updates `favoriteIds` locally, then syncs to `cove-user` via `CoveAPIFavoritesRepository` (`POST`/`DELETE /users/me/favorites/{itemId}`)
 - Used by `LikeButton` to read and mutate favorite state across all views
 
 ---

--- a/docs/LLM_INTEGRATION_IDEAS.md
+++ b/docs/LLM_INTEGRATION_IDEAS.md
@@ -5,12 +5,12 @@ Potential ways to incorporate LLMs into Cove as production features.
 ## User-Facing Features
 
 ### Natural Language Search
-Let users query items in plain English (e.g. "affordable consciously sourced coffee under $20"). An LLM translates the query into structured Firestore filter parameters, which are then executed normally.
+Let users query items in plain English (e.g. "affordable consciously sourced coffee under $20"). An LLM translates the query into structured discovery parameters for `GET /discovery` (query text, category, filters), which are then executed normally.
 
-**Note:** Requires a reasonably populated database to feel useful. Seed Firestore with 20-30 items across categories before building this out.
+**Note:** Requires a reasonably populated catalog to feel useful. Seed the `catalog` schema with 20-30 items across categories before building this out.
 
 ### Admin Item Ingestion
-Paste a brand's website URL or item description into an admin form. An LLM extracts structured data (name, price, category, tags, ethical certifications) and pre-fills a Firestore document for review and publishing.
+Paste a brand's website URL or item description into an admin form. An LLM extracts structured data (name, price, category, tags, ethical certifications) and pre-fills a `catalog.items` row (via `cove-item`) for review and publishing.
 
 **Why build this:** Directly solves the sparse-data problem while demonstrating LLM integration. A two-for-one.
 
@@ -21,10 +21,10 @@ Surface items with an explanation of why they were recommended ("Based on your i
 When item reviews are added, summarize sentiment into a "what buyers say" blurb shown on the item detail screen.
 
 ### Brand Storytelling
-A "tell me about this brand" button that synthesizes a brand's Firestore data into a short narrative paragraph shown on the brand page.
+A "tell me about this brand" button that synthesizes a maker's catalog data into a short narrative paragraph shown on the brand page.
 
 ### Onboarding Quiz
-Ask a few free-text questions about the user's values (sustainability priorities, budget, preferred categories). Use an LLM to interpret answers into structured user preferences stored in Firestore and used for personalization.
+Ask a few free-text questions about the user's values (sustainability priorities, budget, preferred categories). Use an LLM to interpret answers into structured user preferences stored as `profile.interests` (via `cove-user`) and used for personalization.
 
 ## Backend / Pipeline
 
@@ -37,11 +37,11 @@ The **admin item ingestion** tool is the best starting point:
 - Unblocks the data problem
 - Scoped and buildable without a full backend
 - Clearly demonstrates LLM-in-production experience
-- Can be a simple SwiftUI admin form + Cloud Run function + Firestore write
+- Can be a simple SwiftUI admin form + a backend endpoint that writes to the `catalog` schema (via `cove-item`)
 
 ## Stack Considerations
 
-- Call LLM APIs from a **Cloud Run function** (keeps API keys server-side, not in the iOS app)
+- Call LLM APIs from a **backend service** on the cluster, server-side (keeps API keys out of the iOS app)
 - Use the **Anthropic Claude API** or OpenAI API
 - Return structured JSON from the LLM using tool use / structured outputs
 - Log all LLM inputs and outputs for observability

--- a/docs/MEDIA_ARCHITECTURE.md
+++ b/docs/MEDIA_ARCHITECTURE.md
@@ -10,7 +10,7 @@
 - [Variant catalog](#variant-catalog)
 - [Serving variants](#serving-variants)
 - [Picking variants on iOS](#picking-variants-on-ios)
-- [Vendor upload flow](#vendor-upload-flow)
+- [Maker upload flow](#maker-upload-flow)
 - [The imgproxy URL — anatomy](#the-imgproxy-url--anatomy)
 - [Auth model](#auth-model)
 - [Caching](#caching)
@@ -26,7 +26,7 @@
 Every item in Cove has at least one image, and most have a small gallery. Those images need to:
 
 - Render fast and crisp on every device size (small iPhone to 4K desktop in a future web client)
-- Survive an upload from any vendor's camera (HEIC, JPEG, PNG, oddly-rotated, with embedded GPS metadata)
+- Survive an upload from any maker's camera (HEIC, JPEG, PNG, oddly-rotated, with embedded GPS metadata)
 - Cache aggressively at the edge so the cluster doesn't re-do work
 - Stay safe from URL abuse without breaking how `<img>` and `AsyncImage` work
 
@@ -42,7 +42,7 @@ This doc describes the system that delivers all of that. For the broader data mo
 
 **Phase 3 onwards:** `cove-item` will generate and embed pre-signed variant URLs directly in item list and detail responses. iOS will stop calling `GET /images/{filename}/url` for day-to-day image loading; the signed URL will be available in the response payload alongside the item data.
 
-**Ongoing role:** the endpoint stays deployed and useful for vendor-facing preview flows — e.g., preview a just-uploaded image before it is associated with an item.
+**Ongoing role:** the endpoint stays deployed and useful for maker-facing preview flows — e.g., preview a just-uploaded image before it is associated with an item.
 
 ---
 
@@ -56,11 +56,11 @@ Three pieces, each doing one thing well:
 | **imgproxy** | Generates resized / re-encoded variants on the fly from the canonical source. Open-source, libvips-backed, runs as a single Deployment in the cluster. |
 | **Cloudflare** | Caches every uniquely-URL'd variant at the edge. Once warmed, the cluster never sees that exact URL again. |
 
-The principle that ties them together: **one source of truth, infinite derived views.** Vendors upload once. imgproxy turns that one source into whatever shape a screen needs. Cloudflare remembers every shape and serves it from the edge. The cluster pays the transformation cost exactly once per (image, variant) combination.
+The principle that ties them together: **one source of truth, infinite derived views.** Makers upload once. imgproxy turns that one source into whatever shape a screen needs. Cloudflare remembers every shape and serves it from the edge. The cluster pays the transformation cost exactly once per (image, variant) combination.
 
 ```mermaid
 flowchart LR
-    Vendor["Vendor app"] -->|"POST /images (bytes)"| CImg["cove-image<br/>rotate · strip EXIF<br/>WebP q90 · SHA-256"]
+    Maker["Maker app"] -->|"POST /images (bytes)"| CImg["cove-image<br/>rotate · strip EXIF<br/>WebP q90 · SHA-256"]
     CImg -->|"images/{sha256}.webp"| Garage[("Garage · cove-media<br/>canonical original")]
     Client["iOS app"] -->|"signed variant URL"| CF{"Cloudflare edge<br/>cache hit?"}
     CF -->|hit| Client
@@ -275,9 +275,9 @@ For a future web client, the same response shape maps directly to `<picture>` wi
 
 ---
 
-## Vendor upload flow
+## Maker upload flow
 
-Vendors upload once; the server handles everything that needs to be identical across items.
+Makers upload once; the server handles everything that needs to be identical across items.
 
 ### Minimum requirements (enforced server-side in `cove-image`)
 
@@ -307,10 +307,10 @@ After accepting the upload, `cove-image` runs the bytes through libvips before w
 
 Why each step matters:
 
-- **Strip EXIF** — phone photos embed GPS coordinates by default. Without this, every item image leaks the vendor's location.
+- **Strip EXIF** — phone photos embed GPS coordinates by default. Without this, every item image leaks the maker's location.
 - **Auto-rotate** — phones store the image with the sensor's native orientation and a separate rotation flag. Without rotating during decode, half the uploads display sideways.
 - **WebP quality 90** — visually lossless; ~40-60% smaller than the equivalent JPEG. Cheap storage win.
-- **Content-addressed key** — if a vendor uploads the same image twice (different items, same source photo), Garage stores one object. If a vendor mid-upload retries, we don't pollute storage with half-written objects.
+- **Content-addressed key** — if a maker uploads the same image twice (different items, same source photo), Garage stores one object. If a maker mid-upload retries, we don't pollute storage with half-written objects.
 
 Note: sRGB color-space normalization and HEIC acceptance are deferred to a future iteration (see "What's deferred").
 
@@ -318,11 +318,11 @@ Note: sRGB color-space normalization and HEIC acceptance are deferred to a futur
 
 Upload is decoupled from item association:
 
-1. Vendor app calls `POST /images` with the image bytes → response: `{ media_key, width, height }`
-2. Vendor app calls `POST /items` (or `PATCH`) with the desired role: `{ media_key, role: 'primary' }`
+1. Maker app calls `POST /images` with the image bytes → response: `{ media_key, width, height }`
+2. Maker app calls `POST /items` (or `PATCH`) with the desired role: `{ media_key, role: 'primary' }`
 3. `cove-item` inserts into `media`
 
-This split means a vendor can upload several images and then arrange them — no need for the upload endpoint to know about items.
+This split means a maker can upload several images and then arrange them — no need for the upload endpoint to know about items.
 
 ---
 
@@ -391,7 +391,7 @@ This is the most nuanced part of the architecture. Image URLs need to coexist wi
 |---|---|---|---|
 | **A. Public signed URLs** | Signature makes URL unguessable; anyone with the URL can fetch | ✅ Yes — same URL for all users | Public catalog images |
 | **B. Per-user signed URLs** | Server signs with user UID embedded; each user gets a unique URL | ❌ No — cache fragments per user | Private documents per user |
-| **C. Short-lived signed URLs** | Signature includes expiration; URL works for a window (e.g. 1 hour) | ⚠️ Within the validity window, yes; URLs rotate when keys do | Vendor drafts, time-limited access |
+| **C. Short-lived signed URLs** | Signature includes expiration; URL works for a window (e.g. 1 hour) | ⚠️ Within the validity window, yes; URLs rotate when keys do | Maker drafts, time-limited access |
 | **D. Token-protected URLs** | Every fetch requires a Bearer header | ❌ No — every user pays full transformation cost | Genuinely private data with no cacheability requirement |
 
 ### Recommendation for Cove
@@ -401,8 +401,8 @@ This is the most nuanced part of the architecture. Image URLs need to coexist wi
 | Image class | Strategy | Expiry |
 |---|---|---|
 | Active catalog (`is_active = true` on the item) | Option A — public signed | Effectively unlimited |
-| Vendor drafts (`is_active = false`, not yet published) | Option C — short-lived signed | 1 hour, refreshed via authenticated endpoint |
-| Truly private (future: vendor verification documents, receipts) | Option D — token-protected | Per-request auth, no CDN |
+| Maker drafts (`is_active = false`, not yet published) | Option C — short-lived signed | 1 hour, refreshed via authenticated endpoint |
+| Truly private (future: maker verification documents, receipts) | Option D — token-protected | Per-request auth, no CDN |
 
 The implementation is straightforward: `cove-item` checks the item state when constructing the URL and decides which signing mode to use. imgproxy's `IMGPROXY_TOKEN_EXP` config supports verifying the expiry portion of the signature.
 
@@ -488,7 +488,7 @@ For items with very high traffic, the variants stay warm at the Cloudflare edge 
 
 ## Garbage collection
 
-When an item is deleted, `ON DELETE CASCADE` removes its `media` rows. The Garage objects themselves are **not** automatically removed — we want to keep them briefly in case a vendor changes their mind, and content-addressing means the same image might still be referenced by another item.
+When an item is deleted, `ON DELETE CASCADE` removes its `media` rows. The Garage objects themselves are **not** automatically removed — we want to keep them briefly in case a maker changes their mind, and content-addressing means the same image might still be referenced by another item.
 
 A small periodic job sweeps unreferenced objects:
 
@@ -500,7 +500,7 @@ SELECT DISTINCT media_key FROM catalog.media;
 
 The job lists Garage objects, diffs against the SELECT, and deletes any object that is:
 - Not referenced in `media`
-- Older than 30 days (gives vendors a window to recover)
+- Older than 30 days (gives makers a window to recover)
 
 This stays out of the hot path entirely.
 
@@ -510,14 +510,14 @@ This stays out of the hot path entirely.
 
 These are real future requirements but explicitly out of scope for v1:
 
-- **HEIC input** — iPhone's default capture format. govips supports it when built with HEIC support; defer until vendor upload UX exists and we can test end-to-end.
+- **HEIC input** — iPhone's default capture format. govips supports it when built with HEIC support; defer until maker upload UX exists and we can test end-to-end.
 - **sRGB color-space normalization** — Adobe RGB and P3 sources render with shifted colors when imgproxy converts at delivery time. Normalizing on upload avoids surprises; deferred because most phone uploads are already sRGB.
 - **Videos** — would need a separate pipeline (HLS/DASH transcoding, manifest generation, per-bandwidth renditions). No imgproxy equivalent for video that fits this stack cleanly.
-- **Documents** (vendor certifications, ingredient lists as PDFs) — would use Option D (token-protected, no transformation, just signed-URL serving).
+- **Documents** (maker certifications, ingredient lists as PDFs) — would use Option D (token-protected, no transformation, just signed-URL serving).
 - **Watermarking** — imgproxy supports it; not a v1 requirement.
 - **AI-driven cropping** (face detection, salient-object detection) — imgproxy supports `gravity:smart`; defer until v1 catalog shows it's needed.
 - **AVIF output** — modern format, ~20% smaller than WebP. Add as a new variant suffix when iOS / web client adoption justifies the imgproxy CPU cost increase.
-- **Per-vendor signing keys** — would let us revoke one vendor's image access without rotating the global key. Defer until vendor portal exists.
+- **Per-maker signing keys** — would let us revoke one maker's image access without rotating the global key. Defer until maker portal exists.
 
 Each of these can slot in without disturbing the v1 architecture — add a new endpoint, new variant, new field on `media`, or new background job. The data model and serving model don't need to change to accommodate them.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ Welcome to the documentation for the Cove iOS app.
 
 ### Backend Reference
 - **[Postgres Primer](POSTGRES_PRIMER.md)** - Schemas, indexes, EXPLAIN ANALYZE, transactions, JSONB, full-text search, and ltree — the concepts Cove's backend depends on
-- **[Media Architecture](MEDIA_ARCHITECTURE.md)** - Image storage in Garage, on-the-fly transformation via imgproxy, the variant catalog, vendor upload normalization, signed-URL auth model, and Cloudflare caching
+- **[Media Architecture](MEDIA_ARCHITECTURE.md)** - Image storage in Garage, on-the-fly transformation via imgproxy, the variant catalog, maker upload normalization, signed-URL auth model, and Cloudflare caching
 - **[Database Migrations](DATABASE_MIGRATIONS.md)** - How to run golang-migrate against staging and production, dirty-state recovery, per-service migration tables, and superuser boundary rules
 - **[Category Taxonomy](CATEGORY_TAXONOMY.md)** - The full v1 category tree (242 nodes across 9 top-level categories), design principles for tree nodes vs attributes, and the add/remove runbook
 


### PR DESCRIPTION
## Issue

* danicajiao/cove#327

## Summary

Follow-up to #369 closing the residual acceptance-criteria gaps found during post-merge AC verification (AC3 and AC6).

- **`IOS_APP_ARCHITECTURE.md`** — fixed a factual error: `FavoritesStore.toggle` was documented as syncing to **Firestore**; it syncs to `cove-user` via `CoveAPIFavoritesRepository`. Also expanded the auth-routing diagram to all four `AuthState` cases and added a **post-sign-in onboarding** section (username → interests), satisfying AC3's "onboarding flow documented."
- **`LLM_INTEGRATION_IDEAS.md`** — replaced stale `Firestore` datastore references with Postgres/`cove-item`/`cove-user` and the discovery API; replaced stale `Cloud Run function` infra with a cluster backend service.
- **`MEDIA_ARCHITECTURE.md`** — reconciled `vendor` → `maker` throughout (heading, TOC anchor, mermaid node, body) to match the entity model that retired the ambiguous "vendor" term.
- **`README.md`** — aligned the Media Architecture blurb (`vendor` → `maker`).

Remaining `vendor`/`Firestore` mentions are intentional and correct: revision-history entries, the "historical" Firebase data-model section, and the Postgres Primer's deliberate "compare to Firestore" pedagogy.

## Test plan

- [x] `FavoritesStore` no longer documented as syncing to Firestore
- [x] No stale `Firestore`/`Cloud Run` references in `LLM_INTEGRATION_IDEAS.md`
- [x] No `vendor` references in `MEDIA_ARCHITECTURE.md` or the `README.md` blurb
- [x] Onboarding flow (username + interests) documented in `IOS_APP_ARCHITECTURE.md`
- [x] Auth-routing diagram covers all four `AuthState` cases
- [x] mermaid diagrams render correctly on GitHub (visual check)

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)
