### PR TITLE
Add image_key to categories table and seed 59 category images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,10 @@ This rule applies to every agent **and** to the main session. If the MCP propaga
 
 Every PR body written to a `--body-file` must follow this layout. The `## Issue` section is required whenever the branch name contains `<REPO>-<ISSUE-NO>`; omit it for off-cycle branches with no associated issue.
 
+**PR title rules:**
+- Never include the issue reference in the title — no `(#373)`, `[#373]`, or similar suffix. The issue link belongs in the body (`## Issue` + `Closes #N`), not the title.
+- Keep it under 72 characters, imperative mood, sentence case (matches commit message style).
+
 ```bash
 cat > /tmp/pr-body.md << 'EOF'
 ## Issue

--- a/docs/DATABASE_MIGRATIONS.md
+++ b/docs/DATABASE_MIGRATIONS.md
@@ -22,7 +22,14 @@ Cove uses [golang-migrate](https://github.com/golang-migrate/migrate) for schema
 | `cove-item` | `services/cove-item/migrations/` | `directory`, `catalog` |
 | `cove-user` | `services/cove-user/migrations/` | `profile` |
 
-Migrations are plain SQL files in numbered pairs (`000001_name.up.sql` / `000001_name.down.sql`). golang-migrate tracks the current version in a `schema_migrations` table it manages in the `public` schema of the `cove` database.
+Migrations are plain SQL files in numbered pairs (`000001_name.up.sql` / `000001_name.down.sql`). golang-migrate tracks the current version in a per-service table in the `public` schema of the `cove` database:
+
+| Service | Tracking table |
+|---|---|
+| `cove-item` | `public.schema_migrations_cove_item` |
+| `cove-user` | `public.schema_migrations_cove_user` |
+
+Both services share the same `cove` database, so a separate table per service is required — a single shared `schema_migrations` table would conflict when the two services are at different migration versions. The table name is passed to golang-migrate via `x-migrations-table` in the connection string (see [Running migrations](#running-migrations)).
 
 **cove-item migrations must run before cove-user** — the `profile` schema has cross-schema foreign keys into `catalog` and `directory`.
 
@@ -115,12 +122,12 @@ migrate \
 
 ```bash
 # List schemas
-kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c "\dn"
+kubectl exec -n cove-staging cove-db-1 -c postgres -- psql -U postgres -d cove -c "\dn"
 
 # List tables in a schema
-kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c "\dt directory.*"
-kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c "\dt catalog.*"
-kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove -c "\dt profile.*"
+kubectl exec -n cove-staging cove-db-1 -c postgres -- psql -U postgres -d cove -c "\dt directory.*"
+kubectl exec -n cove-staging cove-db-1 -c postgres -- psql -U postgres -d cove -c "\dt catalog.*"
+kubectl exec -n cove-staging cove-db-1 -c postgres -- psql -U postgres -d cove -c "\dt profile.*"
 ```
 
 ---
@@ -150,7 +157,7 @@ Roles are managed separately via the CNPG cluster bootstrap (`postInitApplicatio
 CNPG's `postgres` superuser uses **peer authentication** inside the pod — no password is needed when connecting from within the same process. Use `kubectl exec` to connect:
 
 ```bash
-kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove
+kubectl exec -n cove-staging cove-db-1 -c postgres -- psql -U postgres -d cove
 ```
 
 ### Superuser-only operations
@@ -162,7 +169,7 @@ Both `CREATE ROLE` and `ALTER ROLE` require superuser privileges. Neither can ru
 `postInitApplicationSQL` only runs at cluster creation time. For existing clusters, roles and search paths must be created once manually:
 
 ```bash
-kubectl exec -n <namespace> cove-db-1 -- psql -U postgres -d cove -c "
+kubectl exec -n <namespace> cove-db-1 -c postgres -- psql -U postgres -d cove -c "
 DO \$\$ BEGIN CREATE ROLE cove_item WITH LOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;
 DO \$\$ BEGIN CREATE ROLE cove_user WITH LOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;
 ALTER ROLE cove_item SET search_path = catalog, directory, public;
@@ -173,10 +180,10 @@ ALTER ROLE cove_user  SET search_path = profile, public;
 Verify roles exist and `search_path` defaults are set:
 ```bash
 # Lists roles and attributes (does not show search_path)
-kubectl exec -n <namespace> cove-db-1 -- psql -U postgres -c "\du"
+kubectl exec -n <namespace> cove-db-1 -c postgres -- psql -U postgres -c "\du"
 
 # Confirms search_path is set — search_path lives in pg_db_role_setting, not \du
-kubectl exec -n <namespace> cove-db-1 -- psql -U postgres -d cove -c \
+kubectl exec -n <namespace> cove-db-1 -c postgres -- psql -U postgres -d cove -c \
   "SELECT rolname, setconfig FROM pg_roles r LEFT JOIN pg_db_role_setting s ON r.oid = s.setrole WHERE rolname IN ('cove_item', 'cove_user');"
 ```
 
@@ -197,11 +204,11 @@ error: Dirty database version 1. Fix and force version.
 **Check the state** (use the service-specific table name):
 ```bash
 # cove-item
-kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove \
+kubectl exec -n cove-staging cove-db-1 -c postgres -- psql -U postgres -d cove \
   -c "SELECT * FROM schema_migrations_cove_item;"
 
 # cove-user
-kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove \
+kubectl exec -n cove-staging cove-db-1 -c postgres -- psql -U postgres -d cove \
   -c "SELECT * FROM schema_migrations_cove_user;"
 ```
 
@@ -211,7 +218,7 @@ If the migration failed cleanly (Postgres rolled back the transaction — most D
 
 ```bash
 # Clear the dirty record (safe if the transaction rolled back)
-kubectl exec -n cove-staging cove-db-1 -- psql -U postgres -d cove \
+kubectl exec -n cove-staging cove-db-1 -c postgres -- psql -U postgres -d cove \
   -c "DELETE FROM schema_migrations_cove_item;"  # or schema_migrations_cove_user
 
 # Then rerun

--- a/services/cove-item/migrations/000011_add_category_image_key.down.sql
+++ b/services/cove-item/migrations/000011_add_category_image_key.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE catalog.categories DROP COLUMN image_key;

--- a/services/cove-item/migrations/000011_add_category_image_key.up.sql
+++ b/services/cove-item/migrations/000011_add_category_image_key.up.sql
@@ -1,0 +1,5 @@
+-- Add nullable image_key column to catalog.categories.
+-- Stores the Garage object key for the category card background image,
+-- e.g. "images/categories/food-coffee.jpg". Nullable: not every category
+-- has a dedicated background image.
+ALTER TABLE catalog.categories ADD COLUMN image_key TEXT;

--- a/services/cove-item/migrations/000012_seed_category_image_keys.down.sql
+++ b/services/cove-item/migrations/000012_seed_category_image_keys.down.sql
@@ -1,0 +1,1 @@
+UPDATE catalog.categories SET image_key = NULL;

--- a/services/cove-item/migrations/000012_seed_category_image_keys.up.sql
+++ b/services/cove-item/migrations/000012_seed_category_image_keys.up.sql
@@ -1,0 +1,73 @@
+-- Seed image_key for all 59 category card backgrounds uploaded to Garage in #372.
+-- Only top-level and mid-level categories have images; leaf sub-categories
+-- (e.g. food.coffee.whole_bean) are intentionally left NULL.
+-- Key format: images/categories/<slug>.jpg
+
+UPDATE catalog.categories SET image_key = 'images/categories/alcohol.jpg'              WHERE path = 'alcohol';
+UPDATE catalog.categories SET image_key = 'images/categories/alcohol-beer.jpg'          WHERE path = 'alcohol.beer';
+UPDATE catalog.categories SET image_key = 'images/categories/alcohol-cider.jpg'         WHERE path = 'alcohol.cider';
+UPDATE catalog.categories SET image_key = 'images/categories/alcohol-spirits.jpg'       WHERE path = 'alcohol.spirits';
+UPDATE catalog.categories SET image_key = 'images/categories/alcohol-wine.jpg'          WHERE path = 'alcohol.wine';
+
+UPDATE catalog.categories SET image_key = 'images/categories/apparel.jpg'               WHERE path = 'apparel';
+UPDATE catalog.categories SET image_key = 'images/categories/apparel-accessories.jpg'   WHERE path = 'apparel.accessories';
+UPDATE catalog.categories SET image_key = 'images/categories/apparel-jewelry.jpg'       WHERE path = 'apparel.jewelry';
+UPDATE catalog.categories SET image_key = 'images/categories/apparel-mens.jpg'          WHERE path = 'apparel.mens';
+UPDATE catalog.categories SET image_key = 'images/categories/apparel-unisex.jpg'        WHERE path = 'apparel.unisex';
+UPDATE catalog.categories SET image_key = 'images/categories/apparel-womens.jpg'        WHERE path = 'apparel.womens';
+
+UPDATE catalog.categories SET image_key = 'images/categories/art.jpg'                   WHERE path = 'art';
+UPDATE catalog.categories SET image_key = 'images/categories/art-drawings.jpg'          WHERE path = 'art.drawings';
+UPDATE catalog.categories SET image_key = 'images/categories/art-materials.jpg'         WHERE path = 'art.materials';
+UPDATE catalog.categories SET image_key = 'images/categories/art-paintings.jpg'         WHERE path = 'art.paintings';
+UPDATE catalog.categories SET image_key = 'images/categories/art-photography.jpg'       WHERE path = 'art.photography';
+UPDATE catalog.categories SET image_key = 'images/categories/art-prints.jpg'            WHERE path = 'art.prints';
+UPDATE catalog.categories SET image_key = 'images/categories/art-sculptures.jpg'        WHERE path = 'art.sculptures';
+
+UPDATE catalog.categories SET image_key = 'images/categories/beauty.jpg'                WHERE path = 'beauty';
+UPDATE catalog.categories SET image_key = 'images/categories/beauty-bodycare.jpg'       WHERE path = 'beauty.bodycare';
+UPDATE catalog.categories SET image_key = 'images/categories/beauty-cosmetics.jpg'      WHERE path = 'beauty.cosmetics';
+UPDATE catalog.categories SET image_key = 'images/categories/beauty-fragrance.jpg'      WHERE path = 'beauty.fragrance';
+UPDATE catalog.categories SET image_key = 'images/categories/beauty-haircare.jpg'       WHERE path = 'beauty.haircare';
+UPDATE catalog.categories SET image_key = 'images/categories/beauty-skincare.jpg'       WHERE path = 'beauty.skincare';
+UPDATE catalog.categories SET image_key = 'images/categories/beauty-supplements.jpg'    WHERE path = 'beauty.supplements';
+
+UPDATE catalog.categories SET image_key = 'images/categories/food.jpg'                  WHERE path = 'food';
+UPDATE catalog.categories SET image_key = 'images/categories/food-baked-goods.jpg'      WHERE path = 'food.baked_goods';
+UPDATE catalog.categories SET image_key = 'images/categories/food-beverages.jpg'        WHERE path = 'food.beverages';
+UPDATE catalog.categories SET image_key = 'images/categories/food-coffee.jpg'           WHERE path = 'food.coffee';
+UPDATE catalog.categories SET image_key = 'images/categories/food-condiments.jpg'       WHERE path = 'food.condiments';
+UPDATE catalog.categories SET image_key = 'images/categories/food-confections.jpg'      WHERE path = 'food.confections';
+UPDATE catalog.categories SET image_key = 'images/categories/food-dairy.jpg'            WHERE path = 'food.dairy';
+UPDATE catalog.categories SET image_key = 'images/categories/food-fresh.jpg'            WHERE path = 'food.fresh';
+UPDATE catalog.categories SET image_key = 'images/categories/food-pantry.jpg'           WHERE path = 'food.pantry';
+UPDATE catalog.categories SET image_key = 'images/categories/food-preserves.jpg'        WHERE path = 'food.preserves';
+UPDATE catalog.categories SET image_key = 'images/categories/food-produce.jpg'          WHERE path = 'food.produce';
+-- Note: slug is "food-protein" (without trailing s) but the ltree path is "food.proteins"
+UPDATE catalog.categories SET image_key = 'images/categories/food-protein.jpg'          WHERE path = 'food.proteins';
+UPDATE catalog.categories SET image_key = 'images/categories/food-snacks.jpg'           WHERE path = 'food.snacks';
+UPDATE catalog.categories SET image_key = 'images/categories/food-tea.jpg'              WHERE path = 'food.tea';
+
+UPDATE catalog.categories SET image_key = 'images/categories/home.jpg'                  WHERE path = 'home';
+UPDATE catalog.categories SET image_key = 'images/categories/home-decor.jpg'            WHERE path = 'home.decor';
+UPDATE catalog.categories SET image_key = 'images/categories/home-furniture.jpg'        WHERE path = 'home.furniture';
+UPDATE catalog.categories SET image_key = 'images/categories/home-kitchen.jpg'          WHERE path = 'home.kitchen';
+UPDATE catalog.categories SET image_key = 'images/categories/home-textiles.jpg'         WHERE path = 'home.textiles';
+
+UPDATE catalog.categories SET image_key = 'images/categories/music.jpg'                 WHERE path = 'music';
+UPDATE catalog.categories SET image_key = 'images/categories/music-accessories.jpg'     WHERE path = 'music.accessories';
+UPDATE catalog.categories SET image_key = 'images/categories/music-instruments.jpg'     WHERE path = 'music.instruments';
+UPDATE catalog.categories SET image_key = 'images/categories/music-recorded.jpg'        WHERE path = 'music.recorded';
+
+UPDATE catalog.categories SET image_key = 'images/categories/pets.jpg'                  WHERE path = 'pets';
+UPDATE catalog.categories SET image_key = 'images/categories/pets-birds.jpg'            WHERE path = 'pets.birds';
+UPDATE catalog.categories SET image_key = 'images/categories/pets-cats.jpg'             WHERE path = 'pets.cats';
+UPDATE catalog.categories SET image_key = 'images/categories/pets-dogs.jpg'             WHERE path = 'pets.dogs';
+UPDATE catalog.categories SET image_key = 'images/categories/pets-exotic.jpg'           WHERE path = 'pets.exotic';
+
+UPDATE catalog.categories SET image_key = 'images/categories/plants.jpg'                WHERE path = 'plants';
+UPDATE catalog.categories SET image_key = 'images/categories/plants-dried.jpg'          WHERE path = 'plants.dried';
+UPDATE catalog.categories SET image_key = 'images/categories/plants-indoor.jpg'         WHERE path = 'plants.indoor';
+UPDATE catalog.categories SET image_key = 'images/categories/plants-outdoor.jpg'        WHERE path = 'plants.outdoor';
+UPDATE catalog.categories SET image_key = 'images/categories/plants-plantcare.jpg'      WHERE path = 'plants.plantcare';
+UPDATE catalog.categories SET image_key = 'images/categories/plants-seeds.jpg'          WHERE path = 'plants.seeds';


### PR DESCRIPTION
## Issue

* danicajiao/cove#373

## Summary

- Migration 000011 adds a nullable `image_key TEXT` column to `catalog.categories`
- Migration 000012 seeds the Garage object key for all 59 category card backgrounds (uploaded in #372)
- One entry per category at the top and mid level; leaf sub-categories (e.g. `food.coffee.whole_bean`) are intentionally NULL
- Down migration for 012 nulls all keys; down migration for 011 drops the column
- Fixed `docs/DATABASE_MIGRATIONS.md`: corrected per-service tracking table names (`schema_migrations_cove_item` / `schema_migrations_cove_user`) and added missing `-c postgres` flag to all `kubectl exec` commands

## Test plan

- [x] Apply migrations on staging — `000011` adds column, `000012` populates 59 rows
- [x] Verify count: `SELECT COUNT(*) FROM catalog.categories WHERE image_key IS NOT NULL;` returned 59
- [x] Verify `food.proteins` maps to `images/categories/food-protein.jpg` (slug has no trailing s)
- [x] Roll back `down 2` then re-apply `up` cleanly without errors
- [x] CI passes (Docker build)

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
